### PR TITLE
Add tests for concurrent submissions

### DIFF
--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -474,9 +474,11 @@ class ExecutorTest:
         fb = executor.submit(self.return_inputs, 'chain b', 3)
         fb.add_done_callback(_collect_and_submit_next)
         assert fa.result() == ('chain a', 5)
-        assert 5 in collected['chain a']
+        time.sleep(.001)
+        assert 5 in collected['chain a'], collected
         assert fb.result() == ('chain b', 3)
-        assert 3 in collected['chain b']
+        time.sleep(.001)
+        assert 3 in collected['chain b'], collected
         patience = 500
         while True:
             if (collected['chain a'] == [5, 4, 3, 2, 1, 0] and

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -21,11 +21,14 @@ import threading
 import time
 import pytest
 import weakref
+from math import sqrt
+from collections import defaultdict
+from threading import Thread
+import traceback
 import loky._base as futures
 from loky._base import (PENDING, RUNNING, CANCELLED, CANCELLED_AND_NOTIFIED,
                         FINISHED, Future)
 from loky.process_executor import BrokenExecutor
-import multiprocessing as mp
 
 
 def create_future(state=PENDING, exception=None, result=None):
@@ -408,3 +411,81 @@ class ExecutorTest:
         cause = exc.__cause__
         assert type(cause) is process_executor._RemoteTraceback
         assert 'raise RuntimeError(123)  # some comment' in cause.tb
+
+    def _test_thread_safety(self, thread_idx, results):
+        try:
+            # submit a mix of very simple tasks with map and submit,
+            # cancel some of them and check the results
+            map_future_1 = self.executor.map(sqrt, range(40), timeout=10)
+            if thread_idx % 2 == 0:
+                # Make it more likely for scheduling threads to overtake one
+                # another
+                time.sleep(0.001)
+            submit_futures = [self.executor.submit(time.sleep, 0.0001)
+                              for i in range(20)]
+            for i, f in enumerate(submit_futures):
+                if i % 2 == 0:
+                    f.cancel()
+            map_future_2 = self.executor.map(sqrt, range(40), timeout=10)
+
+            assert list(map_future_1) == [sqrt(x) for x in range(40)]
+            assert list(map_future_2) == [sqrt(i) for i in range(40)]
+            for i, f in enumerate(submit_futures):
+                if i % 2 == 1 or not f.cancelled():
+                    assert f.result(timeout=10) is None
+            results[thread_idx] = 'ok'
+        except Exception as e:
+            # Ensure that py.test can report the content of the exception
+            results[thread_idx] = traceback.format_exc()
+
+    def test_thread_safety(self, exit_on_deadlock):
+        # Check that our process-pool executor can be shared to schedule work
+        # by concurrent threads
+        threads = []
+        results = [None] * 10
+        for i in range(len(results)):
+            threads.append(Thread(target=self._test_thread_safety,
+                                  args=(i, results)))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        for result in results:
+            if result != "ok":
+                raise AssertionError(result)
+
+    @classmethod
+    def return_inputs(cls, *args):
+        return args
+
+    def test_submit_from_callback(self):
+        collected = defaultdict(list)
+        executor = self.executor
+
+        def _collect_and_submit_next(future):
+            name, count = future.result()
+            collected[name].append(count)
+            if count > 0:
+                future = executor.submit(self.return_inputs, name, count - 1)
+                future.add_done_callback(_collect_and_submit_next)
+
+        fa = executor.submit(self.return_inputs, 'chain a', 5)
+        fa.add_done_callback(_collect_and_submit_next)
+        fb = executor.submit(self.return_inputs, 'chain b', 3)
+        fb.add_done_callback(_collect_and_submit_next)
+        assert fa.result() == ('chain a', 5)
+        assert 5 in collected['chain a']
+        assert fb.result() == ('chain b', 3)
+        assert 3 in collected['chain b']
+        patience = 500
+        while True:
+            if (collected['chain a'] == [5, 4, 3, 2, 1, 0] and
+                    collected['chain b'] == [3, 2, 1, 0]):
+                # the recursive callback chains have completed successfully
+                break
+            elif patience < 0:
+                raise AssertionError("callback submit chains stalled at: %r"
+                                     % collected)
+            else:
+                patience -= 1
+                time.sleep(0.01)


### PR DESCRIPTION
The joblib integration requires that job submission should be thread-safe (from a shared executor instance). This seems to be the case in the current queue based design. I added some tests to check some possible concurrent thread-based submission scenarii.

In particular I added a test to submit new tasks from a callback managed by the executor instance itself.

The fact that our executor is thread safe make it possible to remove the thread-local protection of the `get_reusable_executor` method. This will be tackled in another PR.