### PR TITLE
Setup test coverage with subprocess support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 concurrency = multiprocessing
+parallel = True
 source =
     loky
 omit =

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -26,4 +26,6 @@ $PIP install psutil pytest coverage codecov
 [ $ver -lt 33 ] && $PIP install faulthandler
 [ $ver -lt 33 ] && $PIP install futures
 
+# Install support for test coverage reporting for code executed in subprocesses
+$PYTHON continuous_integration/install_coverage_subprocess_pth.py
 $PYTHON setup.py develop

--- a/continuous_integration/install_coverage_subprocess_pth.py
+++ b/continuous_integration/install_coverage_subprocess_pth.py
@@ -1,0 +1,16 @@
+# Make it possible to enable test coverage reporting for Python
+# code run in children processes.
+# http://coverage.readthedocs.io/en/latest/subprocess.html
+
+import os.path as op
+from distutils.sysconfig import get_python_lib
+
+FILE_CONTENT = u"""\
+import coverage; coverage.process_startup()
+"""
+
+filename = op.join(get_python_lib(), 'coverage_subprocess.pth')
+with open(filename, 'wb') as f:
+    f.write(FILE_CONTENT.encode('ascii'))
+
+print('Installed subprocess coverage support: %s' % filename)

--- a/continuous_integration/test_script.sh
+++ b/continuous_integration/test_script.sh
@@ -11,9 +11,12 @@ AUXFILE=.aux$ver
 DEADLOCK=.exit_on_lock
 
 $PYTHON --version
-coverage run --parallel-mode -m pytest -vs 2>$AUXFILE
-coverage combine
+
+# Run the tests and collect trace coverage data both in the subprocesses
+# and its subprocesses.
+COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" py.test -vs 2>$AUXFILE
 res_test=$?
+coverage combine
 [ $res_test -ne 0 ] &&cat $AUXFILE
 [ -e "$DEADLOCK" ] && cat $DEADLOCK
 rm $AUXFILE

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,15 @@ envlist = py27,py33,py34,py35,py36
 
 [testenv]
 passenv = NUMBER_OF_PROCESSORS
-deps=pytest
+deps =
+     pytest
      psutil
      coverage
      numpy ; python_version == '3.5'
      faulthandler ; python_version < '3.3'
+setenv =
+     COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 commands =
-     coverage run --parallel-mode -m pytest {posargs:-xv}
+     python continuous_integration/install_coverage_subprocess_pth.py
+     py.test {posargs:-xv}
      coverage combine --append


### PR DESCRIPTION
This PR configures both tox and travis to use the `COVERAGE_PROCESS_START` environment variable in conjunction with a `.pth` file that enables coverage traces with `import coverage; coverage.process_startup()` so as to collect coverage data both in the main process and all its children process.

http://coverage.readthedocs.io/en/latest/subprocess.html

This setting could be further simplified by using tox in travis via the `TOXENV` variable but thus will be done in a later PR.