### PR TITLE
[MRG] use pytest-timeout globally

### DIFF
--- a/tests/test_process_executor_fork.py
+++ b/tests/test_process_executor_fork.py
@@ -3,7 +3,6 @@ import multiprocessing as mp
 
 from loky import process_executor
 from ._executor_mixin import ExecutorMixin
-from ._test_process_executor import exit_on_deadlock  # noqa
 
 
 if sys.version_info[:2] > (3, 3) and sys.platform != "win32":

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -3,7 +3,6 @@ import multiprocessing as mp
 
 from loky import process_executor
 from ._executor_mixin import ExecutorMixin
-from ._test_process_executor import exit_on_deadlock  # noqa
 
 
 if sys.version_info[:2] > (3, 3) and sys.platform != "win32":

--- a/tests/test_process_executor_loky.py
+++ b/tests/test_process_executor_loky.py
@@ -3,7 +3,6 @@ import multiprocessing as mp
 
 from loky import process_executor
 from ._executor_mixin import ExecutorMixin
-from ._test_process_executor import exit_on_deadlock  # noqa
 
 
 if (sys.version_info[:2] > (3, 3) and sys.platform != "win32") or (

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -3,7 +3,6 @@ import multiprocessing as mp
 
 from loky import process_executor
 from ._executor_mixin import ExecutorMixin
-from ._test_process_executor import exit_on_deadlock  # noqa
 
 
 if sys.version_info[:2] > (3, 3):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = py27,py33,py34,py35,py36
 passenv = NUMBER_OF_PROCESSORS
 deps =
      pytest
+     pytest-timeout
      psutil
      coverage
      numpy ; python_version == '3.5'
@@ -14,5 +15,5 @@ setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 commands =
      python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-xv}
+     py.test {posargs:-xv --timeout=5}
      coverage combine --append


### PR DESCRIPTION
Instead of a custom fixture based on faulthandler that does not interact well with py.test log capture.