### PR TITLE
Test Openmp compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       env: TOXENV="py35" PYTHON="python3"
-      compiler: gcc
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py27" CC='gcc'
+      env: TOXENV="py27"
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py35" PYTHON="python3" CC='gcc'
+      env: TOXENV="py35" PYTHON="python3"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,12 @@ matrix:
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       env: TOXENV="py27"
+      compiler: gcc
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       env: TOXENV="py35" PYTHON="python3"
+      compiler: gcc
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 env:
   global:
     - PYTHON="python"
+    - OMP_NUM_THREADS=4
 matrix:
   include:
     - python: 2.7
@@ -20,18 +21,19 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py27"
+      env: TOXENV="py27" CC='/usr/local/bin/clang-omp'
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py35" PYTHON="python3"
+      env: TOXENV="py35" PYTHON="python3" CC='/usr/local/bin/clang-omp'
 
 before_install:
   - |
     # Install python using brew on OSX
     if [ $TRAVIS_OS_NAME == 'osx' ] && [ $PYTHON == 'python3' ]; then
+
       brew update
-      brew install $PYTHON
+      brew install $PYTHON clang-omp
     fi
 
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,18 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py27" CC='/usr/local/bin/clang-omp'
+      env: TOXENV="py27" CC='gcc'
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py35" PYTHON="python3" CC='/usr/local/bin/clang-omp'
+      env: TOXENV="py35" PYTHON="python3" CC='gcc'
 
 before_install:
   - |
     # Install python using brew on OSX
     if [ $TRAVIS_OS_NAME == 'osx' ] && [ $PYTHON == 'python3' ]; then
-
       brew update
-      brew install $PYTHON clang-omp
+      brew install $PYTHON
     fi
 
 install: pip install tox

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -1,5 +1,10 @@
 
 cd tests/_openmp
 COVERAGE_PROCESS_START=''
-test $PYENV != py36 && python setup.py build_ext -i
-cd ..
+if [[ ${TRAVIS_OS_NAME} = osx ]]; then
+    # Since default gcc on osx is just a front-end for LLVM
+    CC=gcc-4.8 python setup.py build_ext -i
+elif [[ $PYENV != py36 ]]; then
+	python setup.py build_ext -i
+fi
+cd ../..

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -1,10 +1,5 @@
 
 cd tests/_openmp
 COVERAGE_PROCESS_START=''
-if [[ ${TRAVIS_OS_NAME} = osx ]]; then
-    # Since default gcc on osx is just a front-end for LLVM
-    CC=gcc-4.8 python setup.py build_ext -i
-elif [[ $PYENV != py36 ]]; then
-	python setup.py build_ext -i
-fi
+python setup.py build_ext -i
 cd ../..

--- a/continuous_integration/build_test_ext.sh
+++ b/continuous_integration/build_test_ext.sh
@@ -1,0 +1,5 @@
+
+cd tests/_openmp
+COVERAGE_PROCESS_START=''
+test $PYENV != py36 && python setup.py build_ext -i
+cd ..

--- a/continuous_integration/travis/runtests.sh
+++ b/continuous_integration/travis/runtests.sh
@@ -10,4 +10,4 @@ echo $TOXENV
 
 # Run the tests and collect trace coverage data both in the subprocesses
 # and its subprocesses.
-COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" tox -- -v --timeout=15
+COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" tox -- -vl --timeout=15

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -718,13 +718,13 @@ class ProcessPoolExecutor(_base.Executor):
             _threads_wakeup[self._queue_management_thread] = self._wakeup
 
     def _adjust_process_count(self):
-        for _ in range(len(self._processes), self._max_workers):
-            p = self._ctx.Process(
-                target=_process_worker,
-                args=(self._call_queue,
-                      self._result_queue,
-                      self._timeout))
-            with self._manage_processes:
+        with self._manage_processes:
+            for _ in range(len(self._processes), self._max_workers):
+                p = self._ctx.Process(
+                    target=_process_worker,
+                    args=(self._call_queue,
+                          self._result_queue,
+                          self._timeout))
                 p.start()
                 self._processes[p.pid] = p
         mp.util.debug('Adjust process count : {}'.format(self._processes))

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -454,7 +454,11 @@ def _queue_management_worker(executor_reference,
             # itself: we should not mark the executor as broken.
             p = processes.pop(result_item)
             p.join()
-            # Mark the process pool broken so that submits fail right now.
+
+            # Make sure the executor have the right number of worker, event if
+            # a worker timeout while some jobs were submitted. If some work is
+            # pending or there is less processes than runnin items, we need to
+            # start a new Process and raise a warning
             if (len(pending_work_items) > 0
                     or len(running_work_items) > len(processes)):
                 warnings.warn("A worker timeout while some jobs were given to "

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,4 @@
-import os
-import sys
 from setuptools import setup, find_packages
-
-if sys.platform == "darwin":
-    os.environ["CC"] = "gcc-4.8"
-    os.environ["CXX"] = "g++-4.8"
 
 packages = find_packages(exclude=['tests', 'tests._openmp', 'benchmark'])
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup, find_packages
 
-packages = find_packages(exclude=['ez_setup', 't', 't.*'])
+packages = find_packages(exclude=['tests', 'tests._openmp', 'benchmark'])
 
 setup(
     name='loky',
     version='0.1.dev0',
     packages=packages,
     zip_safe=False,
-    license='BSD'
+    license='BSD',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
+import os
+import sys
 from setuptools import setup, find_packages
+
+if sys.platform == "darwin":
+    os.environ["CC"] = "gcc-4.8"
+    os.environ["CXX"] = "g++-4.8"
 
 packages = find_packages(exclude=['tests', 'tests._openmp', 'benchmark'])
 

--- a/tests/_openmp/_fail_fork.py
+++ b/tests/_openmp/_fail_fork.py
@@ -1,0 +1,28 @@
+import random
+import signal
+import multiprocessing as mp
+
+from openmp_parallel_sum import parallel_sum
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser('Test compat openMP/multproc')
+    parser.add_argument('--start', type=str, default='fork',
+                        help='define start method tested with openMP')
+    args = parser.parse_args()
+
+    parallel_sum(10)
+
+    mp.set_start_method(args.start)
+    p = mp.Process(target=parallel_sum, args=(10,))
+
+    def raise_timeout(a, b):
+        print("TIMEOUT - parallel_sum could not complete in less than a sec")
+        p.terminate()
+
+    signal.signal(signal.SIGALRM, raise_timeout)
+    signal.alarm(1)
+    p.start()
+    p.join()
+    print("done")

--- a/tests/_openmp/parallel_sum.pyx
+++ b/tests/_openmp/parallel_sum.pyx
@@ -1,0 +1,13 @@
+import cython
+from cython.parallel import prange
+from libc.stdlib cimport malloc, free
+
+def parallel_sum(int N):
+    cdef double Ysum = 0
+    cdef int i
+    cdef double* X = <double *>malloc(N*cython.sizeof(double))
+
+    for i in prange(N, nogil=True):
+        Ysum += X[i]
+
+    free(X)

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -7,7 +7,6 @@ ext_modules = [
     Extension(
         "parallel_sum",
         ["parallel_sum.pyx"],
-        libraries=["m"],
         extra_compile_args=["-ffast-math", "-fopenmp"],
         extra_link_args=['-fopenmp'],
         )

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -6,8 +6,8 @@ from distutils.extension import Extension
 
 
 if sys.platform == "darwin":
-    os.environ["CC"] = "gcc-4.8"
-    os.environ["CXX"] = "g++-4.8"
+    os.environ["CC"] = "gcc-4.9"
+    os.environ["CXX"] = "g++-4.9"
 
 
 ext_modules = [

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -1,6 +1,13 @@
+import os
+import sys
 from distutils.core import setup
-from distutils.extension import Extension
 from Cython.Build import cythonize
+from distutils.extension import Extension
+
+
+if sys.platform == "darwin":
+    os.environ["CC"] = "gcc-4.8"
+    os.environ["CXX"] = "g++-4.8"
 
 
 ext_modules = [

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -1,0 +1,19 @@
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Build import cythonize
+
+
+ext_modules = [
+    Extension(
+        "parallel_sum",
+        ["parallel_sum.pyx"],
+        libraries=["m"],
+        extra_compile_args=["-ffast-math", "-fopenmp"],
+        extra_link_args=['-fopenmp'],
+        )
+]
+
+setup(
+    name='_openmp',
+    ext_modules=cythonize(ext_modules),
+)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -493,9 +493,10 @@ class ExecutorTest:
     def test_worker_timeout(self):
         self.executor.shutdown(wait=True)
         self.check_no_running_workers(patience=5)
+        timeout = getattr(self, 'min_worker_timeout', .01)
         try:
             self.executor = self.executor_type(
-                max_workers=4, context=self.context, timeout=0.01)
+                max_workers=4, context=self.context, timeout=timeout)
         except NotImplementedError as e:
             self.skipTest(str(e))
 

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -323,9 +323,20 @@ class TestLokyBackend:
                     lines)) == 0
                 assert p.exitcode == 0
 
+    @pytest.mark.skipif(sys.version_info[:2] >= (3, 6),
+                        reason="no wheel for py36. We skip the test to reduce "
+                        " the test running time")
+    def test_compatibility_openmp(self):
+        from ._openmp.parallel_sum import parallel_sum
+        parallel_sum(10)
+        p = self.Process(target=parallel_sum, args=(10,))
+        p.start()
+        p.join()
+
     @staticmethod
     def assertTimingAlmostEqual(t, g):
         assert round(t-g, 1) == 0
+
 
 #
 #

--- a/tests/test_process_executor_fork.py
+++ b/tests/test_process_executor_fork.py
@@ -9,6 +9,12 @@ if sys.version_info[:2] > (3, 3) and sys.platform != "win32":
     class ProcessPoolForkMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = mp.get_context('fork')
+        # Increase the minimal worker timeout for OSX with fork as some weird
+        # behaviors occurs in with this case. This should be investigated but
+        # it is not a priority. With a timeout set at .01, some worker does not
+        # start properly in test_worker_timeout
+        if sys.platform == "darwin":
+                min_worker_timeout = .1
 
     from ._test_process_executor import ExecutorShutdownTest
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist = py27,py33,py34,py35,py36
+skip_missing_interpreters=True
 
 [testenv]
 passenv = NUMBER_OF_PROCESSORS
@@ -9,11 +10,16 @@ deps =
      pytest-timeout
      psutil
      coverage
+     cython ; python_version < '3.6'
      numpy ; python_version == '3.5'
      faulthandler ; python_version < '3.3'
+whitelist_externals=
+     bash
 setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
+     PYENV={envname}
 commands =
+     bash continuous_integration/build_test_ext.sh
      python continuous_integration/install_coverage_subprocess_pth.py
      py.test {posargs:-xv --timeout=5}
      coverage combine --append


### PR DESCRIPTION
Run a simple openMP cython program to ensure the compatibility of our new backend with this library, as proposed in #18 .  
For the moment, appveyor does not seem to allow compillation with openMP, so the test is not good in windows.