### PR TITLE
Concurrent.futures compatible Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       env: TOXENV="py27"
-      compiler: gcc
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312

--- a/loky/backend/__init__.py
+++ b/loky/backend/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 import multiprocessing as mp
-from multiprocessing import Pipe
+from multiprocessing import Pipe, Manager
 if sys.platform != "win32":
     from .process import PosixLokyProcess as Process
 
@@ -64,4 +64,4 @@ if sys.version_info > (3, 4):
         return synchronize.Condition(*args, ctx=_ctx, **kwargs)
 
 __all__ = ["Process", "Queue", "SimpleQueue", "Lock", "RLock", "Semaphore",
-           "BoundedSemaphore", "Condition", "Event", "Pipe"]
+           "BoundedSemaphore", "Condition", "Event", "Pipe", "Manager"]

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -434,8 +434,9 @@ def _queue_management_worker(executor_reference,
             # Mark the process pool broken so that submits fail right now.
             executor = executor_reference()
             if executor is not None:
-                executor._broken = True
-                executor._shutdown_thread = True
+                with executor._shutdown_lock:
+                    executor._broken = True
+                    executor._shutdown_thread = True
                 executor = None
             # All futures in flight must be marked failed
             for work_id, work_item in pending_work_items.items():
@@ -567,8 +568,9 @@ def _shutdown_crash(executor_reference, processes, pending_work_items,
                  "worker processes. " + cause_msg)
     executor = executor_reference()
     if executor is not None:
-        executor._broken = True
-        executor._shutdown_thread = True
+        with executor._shutdown_lock:
+            executor._broken = True
+            executor._shutdown_thread = True
         executor = None
     call_queue.close()
     # Terminate remaining workers forcibly: the queues or their

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -533,6 +533,10 @@ def _management_worker(executor_reference, queue_management_thread, processes,
                                 pending_work_items, call_queue, cause_msg)
             return
         elif _is_crashed(call_queue._thread):
+            executor = executor_reference()
+            if shutting_down():
+                return
+            executor = None
             cause_msg = ("The QueueFeederThread was terminated abruptly "
                          "while feeding a new job. This can be due to "
                          "a job pickling error.")
@@ -544,6 +548,8 @@ def _management_worker(executor_reference, queue_management_thread, processes,
             return
         executor = None
         time.sleep(.1)
+
+    mp.util.debug("_management_worker returning")
 
 
 def _shutdown_crash(executor_reference, processes, pending_work_items,

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -787,9 +787,6 @@ class ProcessPoolExecutor(_base.Executor):
 
     def shutdown(self, wait=True):
         mp.util.debug('shutting down executor %s' % self)
-        if self._kill_on_shutdown:
-            # TODO: implement me!
-            pass
         with self._shutdown_lock:
             self._shutdown_thread = True
         if self._queue_management_thread:

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -115,27 +115,3 @@ class ReusableExecutorMixin:
         assert executor.submit(math.sqrt, 1).result() == 1
         # There can be less than 2 workers because of the worker timeout
         _check_subprocesses_number(executor, expected_max_process_number=2)
-
-
-#
-# Wrapper
-#
-
-class TimingWrapper(object):
-
-    def __init__(self, func):
-        self.func = func
-        self.elapsed = None
-
-    def __call__(self, *args, **kwds):
-        t = time.time()
-        try:
-            return self.func(*args, **kwds)
-        finally:
-            self.elapsed = time.time() - t
-
-    def assert_timing_almost_equal(self, delay):
-        assert round(self.elapsed - delay, 1) == 0
-
-    def assert_timing_almost_zero(self):
-        self.assert_timing_almost_equal(0.0)

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -86,6 +86,8 @@ class ExecutorMixin:
             _check_subprocesses_number(self.executor, self.worker_count)
 
     def teardown_method(self, method):
+        # Make sure is not broken if it should not be
+        assert hasattr(method, 'broken_pool') != (not self.executor._broken)
         t_start = time.time()
         self.executor.shutdown(wait=True)
         dt = time.time() - t_start

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -12,7 +12,7 @@ if sys.platform == "darwin":
 
 ext_modules = [
     Extension(
-        "parallel_sum",
+        "tests._openmp.parallel_sum",
         ["parallel_sum.pyx"],
         extra_compile_args=["-ffast-math", "-fopenmp"],
         extra_link_args=['-fopenmp'],

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -12,7 +12,7 @@ if sys.platform == "darwin":
 
 ext_modules = [
     Extension(
-        "tests._openmp.parallel_sum",
+        "parallel_sum",
         ["parallel_sum.pyx"],
         extra_compile_args=["-ffast-math", "-fopenmp"],
         extra_link_args=['-fopenmp'],

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -31,6 +31,7 @@ from loky._base import (PENDING, RUNNING, CANCELLED, CANCELLED_AND_NOTIFIED,
                         FINISHED, Future)
 from loky.process_executor import BrokenExecutor
 from ._executor_mixin import _running_children_with_cmdline
+from .utils import id_sleep
 
 if sys.version_info[:2] < (3, 3):
     import loky._base as futures
@@ -222,6 +223,11 @@ class WaitTests:
         assert set() == pending
 
     def test_timeout(self):
+
+        # Make sure the executor has already started to avoid timeout happens
+        # before future1 returns
+        assert self.executor.submit(id_sleep, 42).result() == 42
+
         future1 = self.executor.submit(mul, 6, 7)
         future2 = self.executor.submit(time.sleep, 2)
 

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -319,8 +319,7 @@ class ExecutorTest:
         # references.
         my_object = MyObject()
         my_object_collected = threading.Event()
-        my_object_callback = weakref.ref(
-            my_object, lambda obj: my_object_collected.set())
+        _ = weakref.ref(my_object, lambda obj: my_object_collected.set())
         # Deliberately discarding the future.
         self.executor.submit(my_object.my_method)
         del my_object

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -155,8 +155,8 @@ class WaitTests:
                 finished)
         assert set([future1]) == pending
 
-    @staticmethod
-    def wait_and_raise(ev, t):
+    @classmethod
+    def wait_and_raise(cls, ev, t):
         ev.wait(t)
         raise Exception('this is an exception')
 

--- a/tests/script_helper.py
+++ b/tests/script_helper.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-import time
 import zipfile
 import importlib
 import subprocess

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -20,6 +20,7 @@ class TestLokyBackend:
     # interprocess communication objects
     Pipe = staticmethod(backend.Pipe)
     Queue = staticmethod(backend.Queue)
+    Manager = staticmethod(backend.Manager)
 
     # synchronization primitives
     Lock = staticmethod(backend.Lock)
@@ -112,12 +113,17 @@ class TestLokyBackend:
         assert p not in self.active_children()
 
     @classmethod
-    def _test_terminate(cls):
+    def _test_terminate(cls, ev):
+        # Notify the main process that child process started
+        ev.set()
         time.sleep(100)
 
     def test_terminate(self):
 
-        p = self.Process(target=self._test_terminate)
+        mgr = self.Manager()
+        ev = mgr.Event()
+
+        p = self.Process(target=self._test_terminate, args=(ev, ))
         p.daemon = True
         p.start()
 
@@ -135,8 +141,8 @@ class TestLokyBackend:
         join.assert_timing_almost_zero()
         assert p.is_alive()
 
-        # XXX maybe terminating too soon causes the problems on Gentoo...
-        time.sleep(1)
+        # wait for child process to be fully setup
+        ev.wait(1)
 
         p.terminate()
 

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -6,7 +6,7 @@ import signal
 import multiprocessing
 
 from loky import backend
-from ._executor_mixin import TimingWrapper
+from .utils import TimingWrapper
 
 DELTA = 0.1
 
@@ -392,10 +392,14 @@ class TestLokyBackend:
                         " the test running time")
     def test_compatibility_openmp(self):
         from ._openmp.parallel_sum import parallel_sum
+        # Use openMP before launching subprocesses. With fork backend, some fds
+        # are nto correctly clean up, causing a freeze. No freeze should be
+        # detected with loky.
         parallel_sum(10)
         p = self.Process(target=parallel_sum, args=(10,))
         p.start()
         p.join()
+        assert p.exitcode == 0
 
 
 def wait_for_handle(handle, timeout):

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -10,7 +10,8 @@ from pickle import PicklingError, UnpicklingError
 
 from loky.reusable_executor import get_reusable_executor
 from loky.process_executor import BrokenExecutor, ShutdownExecutor
-from ._executor_mixin import ReusableExecutorMixin, TimingWrapper
+from ._executor_mixin import ReusableExecutorMixin
+from .utils import TimingWrapper
 
 try:
     import numpy as np

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -11,7 +11,7 @@ from pickle import PicklingError, UnpicklingError
 from loky.reusable_executor import get_reusable_executor
 from loky.process_executor import BrokenExecutor, ShutdownExecutor
 from ._executor_mixin import ReusableExecutorMixin
-from .utils import TimingWrapper
+from .utils import TimingWrapper, id_sleep
 
 try:
     import numpy as np
@@ -146,12 +146,6 @@ class ErrorAtUnpickle(object):
     """Bad object that triggers a process exit at unpickling time."""
     def __reduce__(self):
         return raise_error, (UnpicklingError, )
-
-
-def id_sleep(x, delay=0):
-    """sleep for delay seconds and return its first argument"""
-    sleep(delay)
-    return x
 
 
 def is_terminated_properly(executor):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,59 @@
+import sys
+import time
+import contextlib
+
+
+@contextlib.contextmanager
+def captured_output(stream_name):
+    """Return a context manager used by captured_stdout/stdin/stderr
+    that temporarily replaces the sys stream *stream_name* with a StringIO."""
+    import io
+    orig_stdout = getattr(sys, stream_name)
+    s = io.StringIO()
+    if sys.version_info[:2] < (3, 3):
+        import types
+        s.wrt = s.write
+
+        def write(self, msg):
+            self.wrt(unicode(msg))
+        s.write = types.MethodType(write, s)
+
+    setattr(sys, stream_name, s)
+    try:
+        yield getattr(sys, stream_name)
+    finally:
+        setattr(sys, stream_name, orig_stdout)
+
+
+def captured_stderr():
+    """Capture the output of sys.stderr:
+
+       with captured_stderr() as stderr:
+           print("hello", file=sys.stderr)
+       self.assertEqual(stderr.getvalue(), "hello\\n")
+    """
+    return captured_output("stderr")
+
+
+#
+# Wrapper
+#
+
+class TimingWrapper(object):
+
+    def __init__(self, func):
+        self.func = func
+        self.elapsed = None
+
+    def __call__(self, *args, **kwds):
+        t = time.time()
+        try:
+            return self.func(*args, **kwds)
+        finally:
+            self.elapsed = time.time() - t
+
+    def assert_timing_almost_equal(self, delay):
+        assert round(self.elapsed - delay, 1) == 0
+
+    def assert_timing_almost_zero(self):
+        self.assert_timing_almost_equal(0.0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,3 +57,13 @@ class TimingWrapper(object):
 
     def assert_timing_almost_zero(self):
         self.assert_timing_almost_equal(0.0)
+
+
+#
+# helper functions
+#
+
+def id_sleep(x, delay=0):
+    """sleep for delay seconds and return its first argument"""
+    time.sleep(delay)
+    return x


### PR DESCRIPTION
Tackles #21 and accelerate the slowest tests.
Use `Event` objects to synchronize the processes in tests.
Improve handeling of Broken vs Shutdown.