### PR TITLE
More tests to check clean shutdown behavior

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -382,7 +382,8 @@ def _queue_management_worker(executor_reference,
 
         # If .join() is not called on the created processes then
         # some multiprocessing.Queue methods may deadlock on Mac OS X.
-        for p in processes.values():
+        while processes:
+            _, p = processes.popitem()
             p.join()
         mp.util.debug("queue management thread clean shutdown of worker "
                       "processes: {}".format(processes))

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -87,12 +87,14 @@ class ExecutorMixin:
 
     def teardown_method(self, method):
         # Make sure is not broken if it should not be
-        assert hasattr(method, 'broken_pool') != (not self.executor._broken)
-        t_start = time.time()
-        self.executor.shutdown(wait=True)
-        dt = time.time() - t_start
-        assert dt < 10, "Executor took too long to shutdown"
-        _check_subprocesses_number(self.executor, 0)
+        executor = getattr(self, 'executor', None)
+        if executor is not None:
+            assert hasattr(method, 'broken_pool') != (not executor._broken)
+            t_start = time.time()
+            executor.shutdown(wait=True)
+            dt = time.time() - t_start
+            assert dt < 10, "Executor took too long to shutdown"
+            _check_subprocesses_number(executor, 0)
 
     def _prime_executor(self):
         # Make sure that the executor is ready to do work before running the

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -113,6 +113,46 @@ class ExecutorShutdownTest:
         for p in processes.values():
             p.join()
 
+    @classmethod
+    def _sleep_and_return(cls, delay, x):
+        time.sleep(delay)
+        return x
+
+    @pytest.mark.wait_on_shutdown
+    def test_processes_terminate_on_executor_gc(self):
+        results = self.executor.map(self._sleep_and_return,
+                                    [0.1] * 10, range(10))
+        assert len(self.executor._processes) == 5
+        processes = self.executor._processes
+
+        # The following should trigger GC and therefore shutdown of workers.
+        # However the shutdown wait for all the pending jobs to complete
+        # first.
+        executor_reference = weakref.ref(self.executor)
+        self.executor = None
+
+        # Make sure that there is not other reference to the executor object.
+        assert executor_reference() == None
+
+        # The remaining jobs should still be processed in the background
+        for result, expected in zip(results, range(10)):
+            assert result == expected
+
+        # Once all pending jobs have completed the executor and threads should
+        # terminate automatically.
+        patience = 10
+        while True:
+            if len(processes) == 0:
+                break
+            patience -= 1
+            if patience < 0:
+                raise AssertionError("queue management thread should have"
+                                     " stopped processes on executor GC:"
+                                     % processes)
+            time.sleep(0.1)
+
+        assert len(processes) == 0
+
     def test_context_manager_shutdown(self):
         with self.executor_type(max_workers=5, context=self.context) as e:
             processes = e._processes

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -85,13 +85,15 @@ class ExecutorShutdownTest:
             from loky.process_executor import {executor_type}
             from time import sleep
             from tests._test_process_executor import sleep_and_print
-            t = {executor_type}(5)
-            t.submit(sleep_and_print, 1.0, "apple")
+            t = {executor_type}(4)
+            t.submit(id, 42).result()
+            t.map(sleep_and_print, [0.1] * 10, range(10))
             """.format(executor_type=self.executor_type.__name__))
         # Errors in atexit hooks don't change the process exit code, check
         # stderr manually.
         assert not err
-        assert out.strip() == b"apple"
+        unique_out_bytes = set(out.replace(b"\r\n", b"").replace(b"\n", b""))
+        assert len(unique_out_bytes) == 10
 
     @pytest.mark.wait_on_shutdown
     def test_hang_issue12364(self):


### PR DESCRIPTION
Either on GC or on main Python program exit.

TODO:
- [ ] add a variant of `test_processes_terminate_on_executor_gc` with all possible crashes