### PR TITLE
Fix semlocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
-      env: TOXENV="py35" PYTHON="python3"
+      env: TOXENV="py36" PYTHON="python3"
 
 before_install:
   - |

--- a/continuous_integration/travis/runtests.sh
+++ b/continuous_integration/travis/runtests.sh
@@ -10,4 +10,5 @@ echo $TOXENV
 
 # Run the tests and collect trace coverage data both in the subprocesses
 # and its subprocesses.
-COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" tox -- -vl --timeout=15
+COVERAGE_PROCESS_START="$TRAVIS_BUILD_DIR/.coveragerc" tox -- -vl --timeout=15 \
+	--maxfail=5

--- a/loky/backend/process.py
+++ b/loky/backend/process.py
@@ -1,6 +1,6 @@
 import os
 import sys
-if sys.version_info > (3, 4):
+if sys.version_info >= (3, 4):
     from multiprocessing.process import BaseProcess
 else:
     from multiprocessing.process import Process as BaseProcess

--- a/loky/backend/semlock.py
+++ b/loky/backend/semlock.py
@@ -81,7 +81,7 @@ def _sem_open(name, value=None):
     if handle == SEM_FAILURE:
         e = ctypes.get_errno()
         if e == errno.EEXIST:
-            raise FileExistsError('cannot find name for semaphore')
+            raise FileExistsError("a semaphore named %s already exists" % name)
         elif e == errno.ENOENT:
             raise FileNotFoundError('cannot find semaphore named %s' % name)
         elif e == errno.ENOSYS:

--- a/loky/backend/semlock.py
+++ b/loky/backend/semlock.py
@@ -57,6 +57,9 @@ if sys.version_info[:2] < (3, 3):
     class FileExistsError(OSError):
         pass
 
+    class FileNotFoundError(OSError):
+        pass
+
 
 def sem_unlink(name):
     if pthread.sem_unlink(name) < 0:
@@ -74,6 +77,7 @@ def _sem_open(name, value=None):
     else:
         handle = pthread.sem_open(ctypes.c_char_p(name), SEM_OFLAG, SEM_PERM,
                                   ctypes.c_int(value))
+
     if handle == SEM_FAILURE:
         e = ctypes.get_errno()
         if e == errno.EEXIST:
@@ -103,7 +107,7 @@ def _sem_timedwait(handle, timeout):
 
     # PERFORMANCE WARNING
     # No sem_timedwait on OSX so we implement our own method. This method can
-    # dergade performances has the wait can have a latency up to 20 msecs
+    # degrade performances has the wait can have a latency up to 20 msecs
     deadline = t_start + timeout
     delay = 0
     now = time.time()

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -26,10 +26,10 @@ __all__ = [
 # See issue 3770
 try:
     if sys.platform != 'win32' and sys.version_info < (3, 4):
-        from .semlock import SemLock as SemLockC
+        from .semlock import SemLock as _SemLock
         from .semlock import sem_unlink
     else:
-        from _multiprocessing import SemLock as SemLockC
+        from _multiprocessing import SemLock as _SemLock
         from _multiprocessing import sem_unlink
 except (ImportError):
     raise ImportError("This platform lacks a functioning sem_open" +
@@ -60,7 +60,7 @@ class SemLock(object):
         unlink_now = sys.platform == 'win32'
         for i in range(100):
             try:
-                self._semlock = SemLockC(
+                self._semlock = _SemLock(
                     kind, value, maxvalue, SemLock._make_name(),
                     unlink_now)
             except FileExistsError:
@@ -115,7 +115,7 @@ class SemLock(object):
         return (h, sl.kind, sl.maxvalue, sl.name)
 
     def __setstate__(self, state):
-        self._semlock = SemLockC._rebuild(*state)
+        self._semlock = _SemLock._rebuild(*state)
         util.debug('recreated blocker with handle %r and name "%s"'
                    % (state[0], state[3].decode()))
         self._make_methods()

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -538,7 +538,8 @@ class ExecutorTest:
         # raise error.
         print("Remaining worker processes command lines:", file=sys.stderr)
         for w, cmdline in workers:
-            print(cmdline, end='\n\n', file=sys.stderr)
+            print(cmdline, end='\n', file=sys.stderr)
+            print(w.status(), end='\n\n', file=sys.stderr)
         raise AssertionError(
             'Expected no more running worker processes but got %d after'
             ' waiting %0.3fs.'

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -8,6 +8,11 @@ import multiprocessing
 from loky import backend
 from .utils import TimingWrapper
 
+try:
+    from ._openmp.parallel_sum import parallel_sum
+except ImportError:
+    parallel_sum = None
+
 DELTA = 0.1
 
 
@@ -393,11 +398,9 @@ class TestLokyBackend:
 
                 assert p.exitcode == 0
 
-    @pytest.mark.skipif(sys.version_info[:2] >= (3, 6),
-                        reason="no wheel for py36. We skip the test to reduce "
-                        " the test running time")
+    @pytest.mark.skipif(parallel_sum is None,
+                        reason="cython is not installed on this system.")
     def test_compatibility_openmp(self):
-        from ._openmp.parallel_sum import parallel_sum
         # Use openMP before launching subprocesses. With fork backend, some fds
         # are nto correctly clean up, causing a freeze. No freeze should be
         # detected with loky.

--- a/tests/test_semlock.py
+++ b/tests/test_semlock.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# @Author: Thomas Moreau
+# @Date:   2016-12-31 12:05:45
+# @Last Modified by:   Thomas Moreau
+# @Last Modified time: 2016-12-31 12:26:39
+import sys
+import pytest
+
+if sys.version_info < (3, 3):
+    FileExistsError = OSError
+    FileNotFoundError = OSError
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="UNIX test")
+def test_semlock_failure():
+    from loky.backend.semlock import SemLock, sem_unlink
+    name = "test1"
+    sl = SemLock(0, 1, 1, name=name)
+
+    with pytest.raises(FileExistsError):
+        SemLock(0, 1, 1, name=name)
+    sem_unlink(sl.name)
+
+    with pytest.raises(FileNotFoundError):
+        SemLock._rebuild(None, 0, 0, name.encode('ascii'))

--- a/tox.ini
+++ b/tox.ini
@@ -21,5 +21,5 @@ setenv =
 commands =
      bash continuous_integration/build_test_ext.sh
      python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-xlv --timeout=5}
+     py.test {posargs:-lv --maxfail=5 --timeout=5}
      coverage combine --append

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ deps =
      pytest-timeout
      psutil
      coverage
-     cython ; python_version < '3.6'
-     numpy ; python_version == '3.5'
+     cython
+     numpy ; python_version == '3.6'
      faulthandler ; python_version < '3.3'
 whitelist_externals=
      bash


### PR DESCRIPTION
There is an issue with our pthread semlock implementation. As we convert the result of `sem_open` to a `ctypes.c_void_p`, SEM_FAILURE does not have the right value and we do not detect failure properly.  
This behavior lead to silent failures such as #42 and should be fixed by properly checking for failure on `sem_open` and handling correctly the error number.