### PR TITLE
[MRG] Make it possible to pass kill_workers=True to get_reusable_executor

### DIFF
--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -30,7 +30,7 @@ def _get_next_executor_id():
 
 
 def get_reusable_executor(max_workers=None, context=None,
-                          timeout=10):
+                          timeout=10, kill_workers=False):
     """Return the current ReusableExectutor instance.
 
     Start a new instance if it has not been started already or if the previous
@@ -53,6 +53,10 @@ def get_reusable_executor(max_workers=None, context=None,
     submitted tasks. Setting ``timeout`` to around 100 times the time required
     to spawn new processes and import packages in them (on the order of 100ms)
     ensures that the overhead of spawning workers is negligible.
+
+    Setting ``kill_workers=True`` makes it possible to forcibly interrupt
+    previously spawned jobs to get a new instance of the reusable executor
+    with new constructor argument values.
     """
     global _executor, _executor_args
     executor = _executor
@@ -77,7 +81,7 @@ def get_reusable_executor(max_workers=None, context=None,
             mp.util.debug("Creating a new executor with max_workers={} as the "
                           "previous instance cannot be reused ({})."
                           .format(max_workers, reason))
-            executor.shutdown(wait=True)
+            executor.shutdown(wait=True, kill_workers=kill_workers)
             _executor = executor = _executor_args = None
             # Recursive call to build a new instance
             return get_reusable_executor(max_workers=max_workers, **args)

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -29,9 +29,9 @@ def _direct_children_with_cmdline(p):
     children_with_cmdline = []
     for c in p.children():
         try:
+            cmdline = " ".join(c.cmdline())
             if not c.is_running():
                 continue
-            cmdline = " ".join(c.cmdline())
             children_with_cmdline.append((c, cmdline))
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -520,15 +520,7 @@ class ExecutorTest:
         while time.time() <= deadline:
             time.sleep(sleep_duration)
             p = psutil.Process()
-            all_children = _running_children_with_cmdline(p)
-            workers = [(c, cmdline) for c, cmdline in all_children
-                       if (u'semaphore_tracker' not in cmdline and
-                           u'multiprocessing.forkserver' not in cmdline)]
-
-            forkservers = [c for c, cmdline in all_children
-                           if u'multiprocessing.forkserver' in cmdline]
-            for fs in forkservers:
-                workers.extend(_running_children_with_cmdline(fs))
+            workers = _running_children_with_cmdline(p)
             if len(workers) == 0:
                 return
 

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -358,6 +358,21 @@ class TestTerminateExecutor(ReusableExecutorMixin):
         with pytest.raises(ShutdownExecutor):
             list(res)
 
+    def test_kill_workers_on_new_options(self):
+        # submit a long running job with no timeout
+        executor = get_reusable_executor(max_workers=2, timeout=None)
+        f = executor.submit(sleep, 10000)
+
+        # change the constructor parameter while requesting not to wait
+        # for the long running task to complete (the workers will get
+        # terminated forcibly)
+        executor = get_reusable_executor(max_workers=2, timeout=5,
+                                         kill_workers=True)
+        with pytest.raises(ShutdownExecutor):
+            f.result()
+        f2 = executor.submit(id_sleep, 42, 0)
+        assert f2.result() == 42
+
 
 class TestResizeExecutor(ReusableExecutorMixin):
     def test_reusable_executor_resize(self):


### PR DESCRIPTION
It might be useful to make it possible to not wait for previous job completion to get a new reusable executor.