### PR TITLE
Refactor backported code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,5 +14,6 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     except Exception
+    def __repr__
 ignore_errors = True
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -13,5 +13,6 @@ exclude_lines =
     pragma: no cover
     raise NotImplementedError
     if __name__ == .__main__.:
+    except Exception
 ignore_errors = True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ matrix:
       env: TOXENV="py34"
     - python: 3.5
       env: TOXENV="py35"
-    - python: "3.6-dev"
+    - python: "3.6"
       env: TOXENV="py36"
+    - python: "3.7-dev"
+      env: TOXENV="py37"
     - os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312

--- a/continuous_integration/appveyor/runtests.ps1
+++ b/continuous_integration/appveyor/runtests.ps1
@@ -3,7 +3,7 @@
 # Authors: Thomas Moreau
 # License: 3-clause BSD
 
-$VERSION=(27, 33, 34, 35)
+$VERSION=(27, 33, 34, 35, 36)
 
 function TestPythonVersions () {
     Write-Host $PYTHON

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -1,0 +1,2 @@
+from .reusable_executor import get_reusable_executor
+

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -1,2 +1,2 @@
-from .reusable_executor import get_reusable_executor
+from .reusable_executor import get_reusable_executor  # noqa: F401
 

--- a/loky/_base.py
+++ b/loky/_base.py
@@ -1,3 +1,12 @@
+###############################################################################
+# Backport concurrent.futures for python2.7/3.3
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from concurrent/futures/_base.py (17/02/2017)
+#  * Do not use yield from
+#  * Use old super syntax
+#
 # Copyright 2009 Brian Quinlan. All Rights Reserved.
 # Licensed to PSF under a Contributor Agreement.
 

--- a/loky/backend/__init__.py
+++ b/loky/backend/__init__.py
@@ -1,9 +1,11 @@
+import os
 import sys
 
 from .context import get_context
 
+LOKY_PICKLER = os.environ.get("LOKY_PICKLER")
+
 if sys.version_info > (3, 4):
-    import os
 
     @staticmethod
     def _make_name():

--- a/loky/backend/_posix_reduction.py
+++ b/loky/backend/_posix_reduction.py
@@ -43,6 +43,8 @@ else:
 
 
 register(socket.socket, _reduce_socket)
+import _socket
+register(_socket.socket, _reduce_socket)
 
 
 if sys.version_info[:2] != (3, 3):

--- a/loky/backend/_posix_reduction.py
+++ b/loky/backend/_posix_reduction.py
@@ -9,7 +9,7 @@ HAVE_SEND_HANDLE = (hasattr(socket, 'CMSG_LEN') and
                     hasattr(socket.socket, 'sendmsg'))
 
 
-def DupFd(fd, type="file descriptor"):
+def DupFd(fd):
     '''Return a wrapper for an fd.'''
 
     from .context import get_spawning_popen
@@ -21,13 +21,13 @@ def DupFd(fd, type="file descriptor"):
         return resource_sharer.DupFd(fd)
     else:
         raise TypeError(
-                'Cannot pickle {} object. This object can only be passed when '
-                'spawning a new process'.format(type)
+                'Cannot pickle connection object. This object can only be '
+                'passed when spawning a new process'
             )
 
 
 def _reduce_socket(s):
-    df = DupFd(s.fileno(), type="socket")
+    df = DupFd(s.fileno())
     return _rebuild_socket, (df, s.family, s.type, s.proto)
 
 
@@ -46,7 +46,7 @@ else:
 
 
 def reduce_connection(conn):
-    df = DupFd(conn.fileno(), type="connection")
+    df = DupFd(conn.fileno())
     return rebuild_connection, (df, conn.readable, conn.writable)
 
 

--- a/loky/backend/_posix_reduction.py
+++ b/loky/backend/_posix_reduction.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import socket
 
@@ -13,6 +14,12 @@ else:
 HAVE_SEND_HANDLE = (hasattr(socket, 'CMSG_LEN') and
                     hasattr(socket, 'SCM_RIGHTS') and
                     hasattr(socket.socket, 'sendmsg'))
+
+
+def _mk_inheritable(fd):
+    if sys.version_info[:2] > (3, 3):
+        os.set_inheritable(fd, True)
+    return fd
 
 
 def DupFd(fd):

--- a/loky/backend/_posix_reduction.py
+++ b/loky/backend/_posix_reduction.py
@@ -1,3 +1,11 @@
+###############################################################################
+# Extra reducers for Unix based system and connections objects
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from multiprocessing/reduction.py (17/02/2017)
+#  * Add adapted reduction for LokyProcesses and socket/Connection
+#
 import os
 import sys
 import socket

--- a/loky/backend/_posix_wait.py
+++ b/loky/backend/_posix_wait.py
@@ -1,5 +1,11 @@
-""" Unix systems wait compat for python2.7
-"""
+###############################################################################
+# Compat for wait function on UNIX based system
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from multiprocessing/connection.py (17/02/2017)
+#  * Backport wait function to python2.7
+#
 
 import platform
 import select

--- a/loky/backend/_win_reduction.py
+++ b/loky/backend/_win_reduction.py
@@ -70,8 +70,9 @@ else:
 
 
 if sys.version_info[:2] < (3, 3):
-    from _multiprocessing.win32 import CloseHandle as close
+    from _multiprocessing import win32
     from multiprocessing.reduction import reduce_handle, rebuild_handle
+    close = win32.CloseHandle
 
     def fromfd(handle, family, type_, proto=0):
         s = socket.socket(family, type_, proto, fileno=handle)

--- a/loky/backend/_win_reduction.py
+++ b/loky/backend/_win_reduction.py
@@ -17,8 +17,12 @@ if sys.version_info[:2] < (3, 3):
 
     from _multiprocessing import win32
     _winapi.OpenProcess = win32.OpenProcess
+
+    from _multiprocessing import Connection, PipeConnection
 else:
     import _winapi
+
+    from multiprocessing.connection import Connection, PipeConnection
 
 
 class DupHandle(object):
@@ -50,12 +54,6 @@ class DupHandle(object):
             _winapi.CloseHandle(proc)
 
 
-if sys.version_info >= (3, 3):
-    from multiprocessing.connection import Connection, PipeConnection
-else:
-    from _multiprocessing import Connection, PipeConnection
-
-
 # make Connection pickable
 def reduce_connection(conn):
     rh = DupHandle(conn.fileno(), _winapi.DUPLICATE_SAME_ACCESS)
@@ -65,6 +63,7 @@ def reduce_connection(conn):
 def rebuild_connection(reduced_handle, readable, writable):
     handle = reduced_handle.detach()
     return Connection(handle, readable=readable, writable=writable)
+
 
 register(Connection, reduce_connection)
 
@@ -81,6 +80,7 @@ def rebuild_pipe_connection(dh, readable, writable):
     handle = dh.detach()
     return PipeConnection(handle, readable, writable)
 
+
 register(PipeConnection, reduce_pipe_connection)
 
 
@@ -92,5 +92,6 @@ def _reduce_socket(s):
 
 def _rebuild_socket(ds):
     return ds.detach()
+
 
 register(socket.socket, _reduce_socket)

--- a/loky/backend/_win_reduction.py
+++ b/loky/backend/_win_reduction.py
@@ -1,10 +1,10 @@
+###############################################################################
+# Extra reducers for Windows system and connections objects
 #
-# Module which deals with pickling of objects.
+# author: Thomas Moreau and Olivier Grisel
 #
-# multiprocessing/reduction.py
-#
-# Copyright (c) 2006-2008, R Oudkerk
-# Licensed to PSF under a Contributor Agreement.
+# adapted from multiprocessing/reduction.py (17/02/2017)
+#  * Add adapted reduction for LokyProcesses and socket/PipeConnection
 #
 import os
 import sys

--- a/loky/backend/_win_reduction.py
+++ b/loky/backend/_win_reduction.py
@@ -17,6 +17,13 @@ if sys.version_info[:2] < (3, 3):
 
     from _multiprocessing import win32
     _winapi.OpenProcess = win32.OpenProcess
+    _winapi.CloseHandle = win32.CloseHandle
+    _winapi.FILE_GENERIC_READ = win32.GENERIC_READ
+    _winapi.FILE_GENERIC_WRITE = win32.GENERIC_WRITE
+
+    # Value found at
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/ms684880(v=vs.85).aspx
+    _winapi.PROCESS_DUP_HANDLE = 0x0040
 
     from _multiprocessing import Connection, PipeConnection
 else:
@@ -54,29 +61,30 @@ class DupHandle(object):
             _winapi.CloseHandle(proc)
 
 
-# make Connection pickable
-def reduce_connection(conn):
-    rh = DupHandle(conn.fileno(), _winapi.DUPLICATE_SAME_ACCESS)
-    return rebuild_connection, (rh, conn.readable, conn.writable)
+# # make Connection pickable
+# def reduce_connection(conn):
+#     rh = DupHandle(conn.fileno(), _winapi.DUPLICATE_SAME_ACCESS)
+#     return rebuild_connection, (rh, conn.readable, conn.writable)
 
 
-def rebuild_connection(reduced_handle, readable, writable):
-    handle = reduced_handle.detach()
-    return Connection(handle, readable=readable, writable=writable)
+# def rebuild_connection(reduced_handle, readable, writable):
+#     handle = reduced_handle.detach()
+#     return Connection(handle, readable=readable, writable=writable)
 
 
-register(Connection, reduce_connection)
+# register(Connection, reduce_connection)
 
 
 def reduce_pipe_connection(conn):
     access = ((_winapi.FILE_GENERIC_READ if conn.readable else 0) |
               (_winapi.FILE_GENERIC_WRITE if conn.writable else 0))
+    print(access)
     dh = DupHandle(conn.fileno(), access)
     return rebuild_pipe_connection, (dh, conn.readable, conn.writable)
 
 
 def rebuild_pipe_connection(dh, readable, writable):
-    from .connection import PipeConnection
+    from multiprocessing.connection import PipeConnection
     handle = dh.detach()
     return PipeConnection(handle, readable, writable)
 
@@ -85,13 +93,31 @@ register(PipeConnection, reduce_pipe_connection)
 
 
 # make sockets pickable
-def _reduce_socket(s):
-    from multiprocessing.resource_sharer import DupSocket
-    return _rebuild_socket, (DupSocket(s),)
+if sys.version_info[:2] > (2, 7):
+    def _reduce_socket(s):
+        from multiprocessing.resource_sharer import DupSocket
+        return _rebuild_socket, (DupSocket(s),)
 
+    def _rebuild_socket(ds):
+        return ds.detach()
+else:
+    from multiprocessing.reduction import reduce_socket as _reduce_socket
+    # def fromfd(handle, family, type_, proto=0):
+    #     s = socket.fromfd(handle, family, type_, proto)
+    #     if s.__class__ is not socket.socket:
+    #         s = socket.socket(_sock=s)
+    #     return s
 
-def _rebuild_socket(ds):
-    return ds.detach()
+    # def _reduce_socket(s):
+    #     access = _winapi.FILE_GENERIC_READ | _winapi.FILE_GENERIC_WRITE
+    #     reduced_handle = DupHandle(s.fileno(), 0)
+    #     return _rebuild_socket, (reduced_handle, s.family, s.type, s.proto)
+
+    # def _rebuild_socket(reduced_handle, family, type_, proto):
+    #     handle = reduced_handle.detach()
+    #     s = fromfd(handle, family, type_, proto)
+    #     _winapi.CloseHandle(handle)
+    #     return s
 
 
 register(socket.socket, _reduce_socket)

--- a/loky/backend/_win_wait.py
+++ b/loky/backend/_win_wait.py
@@ -1,5 +1,11 @@
-""" Windows systems wait compat for python2.7
-"""
+###############################################################################
+# Compat for wait function on Windows system
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from multiprocessing/connection.py (17/02/2017)
+#  * Backport wait function to python2.7
+#
 
 from time import sleep
 import ctypes

--- a/loky/backend/connection.py
+++ b/loky/backend/connection.py
@@ -1,3 +1,8 @@
+###############################################################################
+# Compat file to load the correct wait function
+# 
+# author: Thomas Moreau and Olivier grisel
+#
 import sys
 
 if sys.version_info < (3, 3):

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -92,13 +92,13 @@ class LokyContext(BaseContext):
             multiprocessing objects as it does not rely on fork.
             """
             from multiprocessing import synchronize
-            Semaphore = synchronize.Semaphore
-            BoundedSemaphore = synchronize.BoundedSemaphore
-            Lock = synchronize.Lock
-            RLock = synchronize.RLock
-            Condition = synchronize.Condition
-            Event = synchronize.Event
-            Manager = mp.Manager
+            Semaphore = staticmethod(synchronize.Semaphore)
+            BoundedSemaphore = staticmethod(synchronize.BoundedSemaphore)
+            Lock = staticmethod(synchronize.Lock)
+            RLock = staticmethod(synchronize.RLock)
+            Condition = staticmethod(synchronize.Condition)
+            Event = staticmethod(synchronize.Event)
+            Manager = staticmethod(mp.Manager)
 
     if sys.platform != "win32":
         """For Unix platform, use our custom implementation of synchronize

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -1,12 +1,15 @@
 ###############################################################################
+# Basic context management with LokyContext and  provides
 # compat for UNIX 2.7 and 3.3
-# Context with LokyContext server.
-# This avoids having a Manager using fork and breaks the fd.
 #
-# This just update the start method to use LokyProcess instead of the default
-# Process that use a fork.
+# author: Thomas Moreau and Olivier Grisel
 #
-
+# adapted from multiprocessing/context.py
+#  * Create a context ensuring loky uses only objects that are compatible
+#  * Add LokyContext to the list of context of multiprocessing so loky can be
+#    used with multiprocessing.set_start_method
+#  * Add some compat function for python2.7 and 3.3. 
+#
 
 import sys
 import multiprocessing as mp

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -1,8 +1,14 @@
+###############################################################################
+# Launch a subprocess using forkexec and make sure only the needed fd are
+# shared in the two process.
+#
+# author: Thomas Moreau and Olivier Grisel
+#
 import os
 import sys
 
 if sys.platform == "darwin" and sys.version_info < (3, 3):
-     FileNotFoundError = OSError
+    FileNotFoundError = OSError
 
 
 def close_fds(keep_fds):  # pragma: no cover
@@ -20,7 +26,7 @@ def close_fds(keep_fds):  # pragma: no cover
         open_fds = set(fd for fd in range(3, max_nfds))
         open_fds.add(0)
 
-    for i in open_fds-keep_fds:
+    for i in open_fds - keep_fds:
         try:
             os.close(i)
         except OSError:

--- a/loky/backend/managers.py
+++ b/loky/backend/managers.py
@@ -1,6 +1,12 @@
 ###############################################################################
-# compat for 2.7 and 3.3 Manager with LokyContext
+# compat for UNIX 2.7 and 3.3
+# Manager with LokyContext server.
+# This avoids having a Manager using fork and breaks the fd.
 #
+# This just update the start method to use LokyProcess instead of the default
+# Process that use a fork.
+#
+
 import multiprocessing as mp
 from multiprocessing.managers import SyncManager, State
 from .process import PosixLokyProcess as Process

--- a/loky/backend/managers.py
+++ b/loky/backend/managers.py
@@ -3,8 +3,10 @@
 # Manager with LokyContext server.
 # This avoids having a Manager using fork and breaks the fd.
 #
-# This just update the start method to use LokyProcess instead of the default
-# Process that use a fork.
+# author: Thomas Moreau and Olivier Grisel
+#
+# based on multiprocessing/managers.py (17/02/2017)
+#  * Overload the start method to use LokyContext and launch a loky subprocess
 #
 
 import multiprocessing as mp

--- a/loky/backend/popen_loky.py
+++ b/loky/backend/popen_loky.py
@@ -1,3 +1,8 @@
+###############################################################################
+# Popen for LokyProcess.
+#
+# author: Thomas Moreau and Olivier Grisel
+#
 import os
 import sys
 import signal

--- a/loky/backend/popen_loky.py
+++ b/loky/backend/popen_loky.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
     parser.add_argument('--semaphore', type=int, default=None,
                         help='File handle name for the semaphore tracker')
     parser.add_argument('--name-process', type=str, default=None,
-                        help='Identifiant for debuggging purpose')
+                        help='Identifier for debuggging purpose')
 
     args = parser.parse_args()
 

--- a/loky/backend/process.py
+++ b/loky/backend/process.py
@@ -1,3 +1,11 @@
+###############################################################################
+# PosixLokyProcess implementation
+#
+# authors: Thomas Moreau and Olivier Grisel
+#
+# based on multiprocessing/process.py  (17/02/2017)
+# * Add some compatibility function for python2.7 and 3.3
+#
 import os
 import sys
 if sys.version_info >= (3, 4):

--- a/loky/backend/queues.py
+++ b/loky/backend/queues.py
@@ -1,13 +1,14 @@
+###############################################################################
+# Queue and SimpleQueue implementation for loky
 #
-# Module tweaking queues for loky backend.
-# It permits to implement queues objects in python2.7/3.3 with the right sync
-# primitives.
-# It also allows to add custom reducers to customize the pickling process for
-# the queues.
+# authors: Thomas Moreau, Olivier Grisel
 #
-# Authors: Thomas Moreau and Olivier Grisel
+# based on multiprocessing/queues.py (16/02/2017)
+# * Add some compatibility function for python2.7 and 3.3 and makes sure
+#   it uses the right synchronization primitive.
+# * Add some custom reducers for the Queues/SimpleQueue to tweak the
+#   pickling process. (overload Queue._feed/SimpleQueue.put)
 #
-
 import os
 import sys
 import errno

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -1,5 +1,14 @@
+###############################################################################
+# Customizable Pickler with some basic reducers
+#
+# author: Thomas Moreau
+#
+# adapted from multiprocessing/reduction.py (17/02/2017)
+#  * Replace the ForkingPickler with a similar _LokyPickler,
+#  * Add CustomizableLokyPickler to allow customizing pickling process
+#    on the fly.
+#
 import io
-import os
 import sys
 import functools
 import warnings
@@ -186,6 +195,6 @@ def _rebuild_partial(func, args, keywords):
 register(functools.partial, _reduce_partial)
 
 if sys.platform != "win32":
-    from ._posix_reduction import _mk_inheritable # noqa: F401
+    from ._posix_reduction import _mk_inheritable  # noqa: F401
 else:
     from . import _win_reduction  # noqa: F401

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -216,7 +216,7 @@ def _rebuild_partial(func, args, keywords):
 
 register(functools.partial, _reduce_partial)
 
-if sys.platform == "win32":
-    from . import _win_reduction  # noqa: F401
-else:
+if sys.platform != "win32":
     from . import _posix_reduction  # noqa: F401
+else:
+    from . import _win_reduction  # noqa: F401

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -116,7 +116,7 @@ def main(fd):
         except Exception:
             pass
 
-    if VERBOSE:
+    if VERBOSE:  # pragma: no cover
         sys.stderr.write("Main semaphore tracker is running\n")
         sys.stderr.flush()
 
@@ -129,14 +129,14 @@ def main(fd):
                     cmd, name = line.strip().split(b':')
                     if cmd == b'REGISTER':
                         cache.add(name)
-                        if VERBOSE:
+                        if VERBOSE:  # pragma: no cover
                             name = name.decode('ascii')
                             sys.stderr.write("[SemaphoreTracker] register {}\n"
                                              .format(name))
                             sys.stderr.flush()
                     elif cmd == b'UNREGISTER':
                         cache.remove(name)
-                        if VERBOSE:
+                        if VERBOSE:  # pragma: no cover
                             name = name.decode('ascii')
                             sys.stderr.write("[SemaphoreTracker] unregister {}"
                                              ": cache({})\n"
@@ -165,7 +165,7 @@ def main(fd):
             try:
                 try:
                     sem_unlink(name)
-                    if VERBOSE:
+                    if VERBOSE:  # pragma: no cover
                         name = name.decode('ascii')
                         sys.stderr.write("[SemaphoreTracker] unregister {}\n"
                                          .format(name))
@@ -175,7 +175,7 @@ def main(fd):
             finally:
                 pass
 
-    if VERBOSE:
+    if VERBOSE:  # pragma: no cover
         sys.stderr.write("semaphore tracker shut down\n")
         sys.stderr.flush()
 

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -1,3 +1,14 @@
+###############################################################################
+# Server process to keep track of unlinked semaphores and clean them.
+#
+# author: Thomas Moreau
+#
+# adapted from multiprocessing/semaphore_tracker.py  (17/02/2017)
+#  * include custom spawnv_passfds to start the process
+#  * use custom unlink from our own SemLock implementation
+#  * add some VERBOSE logging
+#
+
 #
 # On Unix we run a server process which keeps track of unlinked
 # semaphores. The server ignores SIGINT and SIGTERM and reads from a

--- a/loky/backend/semlock.py
+++ b/loky/backend/semlock.py
@@ -1,10 +1,15 @@
-"""Ctypes implementation for posix semaphore
-
-only work for fork_exec
-OSX -> no semaphore with value > 1
-
-"""
-
+###############################################################################
+# Ctypes implementation for posix semaphore.
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from cpython/Modules/_multiprocessing/semaphore.c (17/02/2017)
+#  * use ctypes to access pthread semaphores and provide a full python
+#    semaphore management.
+#  * For OSX, as no sem_getvalue is not implemented, Semaphore with value > 1
+#    are not guaranteed to work.
+#  * Only work with PosixLokyProcess
+#
 import os
 import sys
 import time

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -1,3 +1,11 @@
+###############################################################################
+# Prepares and processes the data to setup the new process environment
+#
+# author: Thomas Moreau and Olivier Grisel
+#
+# adapted from multiprocessing/spawn.py (17/02/2017)
+#  * Improve logging data
+#
 import os
 import sys
 import runpy

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -25,7 +25,7 @@ __all__ = [
 # raise ImportError for platforms lacking a working sem_open implementation.
 # See issue 3770
 try:
-    if sys.platform != 'win32' and sys.version_info < (3, 4):
+    if sys.version_info < (3, 4):
         from .semlock import SemLock as _SemLock
         from .semlock import sem_unlink
         from . import semaphore_tracker
@@ -59,17 +59,18 @@ class SemLock(object):
     _rand = tempfile._RandomNameSequence()
 
     def __init__(self, kind, value, maxvalue):
-        unlink_now = sys.platform == 'win32'
+        # unlink_now is only used on win32 or when we are using fork.
+        unlink_now = False 
         for i in range(100):
             try:
                 self._semlock = _SemLock(
                     kind, value, maxvalue, SemLock._make_name(),
                     unlink_now)
-            except FileExistsError:
+            except FileExistsError:  # pragma: no cover
                 pass
             else:
                 break
-        else:
+        else:  # pragma: no cover
             raise FileExistsError('cannot find name for semaphore')
 
         util.debug('created semlock with handle %s and name "%s"'
@@ -77,18 +78,16 @@ class SemLock(object):
 
         self._make_methods()
 
-        if sys.platform != 'win32':
-            def _after_fork(obj):
-                obj._semlock._after_fork()
-            util.register_after_fork(self, _after_fork)
+        def _after_fork(obj):
+            obj._semlock._after_fork()
 
-        if self._semlock.name is not None:
-            # We only get here if we are on Unix with forking
-            # disabled.  When the object is garbage collected or the
-            # process shuts down we unlink the semaphore name
-            semaphore_tracker.register(self._semlock.name)
-            util.Finalize(self, SemLock._cleanup, (self._semlock.name,),
-                          exitpriority=0)
+        util.register_after_fork(self, _after_fork)
+
+        # When the object is garbage collected or the
+        # process shuts down we unlink the semaphore name
+        semaphore_tracker.register(self._semlock.name)
+        util.Finalize(self, SemLock._cleanup, (self._semlock.name,),
+                      exitpriority=0)
 
     @staticmethod
     def _cleanup(name):
@@ -108,10 +107,7 @@ class SemLock(object):
     def __getstate__(self):
         assert_spawning(self)
         sl = self._semlock
-        if sys.platform == 'win32':
-            h = get_spawning_popen().duplicate_for_child(sl.handle)
-        else:
-            h = sl.handle
+        h = sl.handle
         return (h, sl.kind, sl.maxvalue, sl.name)
 
     def __setstate__(self, state):

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -1,10 +1,13 @@
+###############################################################################
+# Synchronization primitives based on our SemLock implementation
 #
-# Module implementing synchronization primitives
+# author: Thomas Moreau and Olivier Grisel
 #
-# multiprocessing/synchronize.py
-#
-# Copyright (c) 2006-2008, R Oudkerk
-# Licensed to PSF under a Contributor Agreement.
+# adapted from multiprocessing/synchronize.py (17/02/2017)
+#  * Remove ctx argument for compatibility reason
+#  * Implementation of Condition/Event are necessary for compatibility
+#    with python2.7/3.3, Barrier should be reimplemented to for those
+#    version (but it is not used in loky).
 #
 
 import os
@@ -14,7 +17,7 @@ import threading
 import _multiprocessing
 from time import time as _time
 
-from .context import assert_spawning, get_spawning_popen
+from .context import assert_spawning
 from multiprocessing import process
 from multiprocessing import util
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -389,7 +389,8 @@ def _queue_management_worker(executor_reference,
         mp.util.debug("queue management thread shutting down")
         executor_flags.flag_as_shutting_down()
         # This is an upper bound
-        nb_children_alive = sum(p.is_alive() for p in processes.values())
+        with processes_management_lock:
+            nb_children_alive = sum(p.is_alive() for p in processes.values())
         try:
             for i in range(0, nb_children_alive):
                 call_queue.put_nowait(None)

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -1,3 +1,8 @@
+###############################################################################
+# Reusable ProcessPoolExecutor
+#
+# author: Thomas Moreau and Olivier Grisel
+#
 import sys
 import time
 import warnings

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -8,7 +8,7 @@ import pytest
 import threading
 
 from loky._base import TimeoutError
-from loky.reusable_executor import get_reusable_executor
+from loky import get_reusable_executor
 from multiprocessing import cpu_count
 from .conftest import logging_setup
 

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -10,7 +10,7 @@ if sys.platform == "darwin":
     os.environ["CXX"] = "g++-4.9"
 
 if sys.platform != "win32":
-    extra_compile_args = ["-ffast-math", "-fopenmp"],
+    extra_compile_args = ["-ffast-math", "-fopenmp"]
     extra_link_args = ['-fopenmp']
 else:
     extra_compile_args = ["/openmp"]
@@ -21,7 +21,7 @@ ext_modules = [
         "parallel_sum",
         ["parallel_sum.pyx"],
         extra_compile_args=extra_compile_args,
-        extra_link_args=extra_link_args,
+        extra_link_args=extra_link_args
         )
 ]
 

--- a/tests/_openmp/setup.py
+++ b/tests/_openmp/setup.py
@@ -9,13 +9,19 @@ if sys.platform == "darwin":
     os.environ["CC"] = "gcc-4.9"
     os.environ["CXX"] = "g++-4.9"
 
+if sys.platform != "win32":
+    extra_compile_args = ["-ffast-math", "-fopenmp"],
+    extra_link_args = ['-fopenmp']
+else:
+    extra_compile_args = ["/openmp"]
+    extra_link_args = None
 
 ext_modules = [
     Extension(
         "parallel_sum",
         ["parallel_sum.pyx"],
-        extra_compile_args=["-ffast-math", "-fopenmp"],
-        extra_link_args=['-fopenmp'],
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
         )
 ]
 

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -88,7 +88,7 @@ class TestLokyBackend:
         sq = self.SimpleQueue()
         args = (q, sq, 1, 2)
         kwargs = {'hello': 23, 'bye': 2.54}
-        name = 'SomeProcess'
+        name = 'TestLokyProcess'
         p = self.Process(
             target=self._test_process, args=args, kwargs=kwargs, name=name
         )

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -17,6 +17,9 @@ except ImportError:
 
 DELTA = 0.1
 ctx_loky = get_context("loky")
+HAVE_SEND_HANDLE = (hasattr(socket, 'CMSG_LEN') and
+                    hasattr(socket, 'SCM_RIGHTS') and
+                    hasattr(socket.socket, 'sendmsg'))
 
 
 class TestLokyBackend:
@@ -169,6 +172,9 @@ class TestLokyBackend:
         p.join()
         s.close()
 
+    @pytest.mark.skipif(not HAVE_SEND_HANDLE,
+                        reason="This system cannot send handle between. "
+                        "Connections object should be shared at spawning.")
     def test_socket_queue(self):
         q = self.SimpleQueue()
 
@@ -205,6 +211,9 @@ class TestLokyBackend:
         rd.close()
         wrt.close()
 
+    @pytest.mark.skipif(not HAVE_SEND_HANDLE,
+                        reason="This system cannot send handle between. "
+                        "Connections object should be shared at spawning.")
     def test_connection_queue(self):
         q = self.SimpleQueue()
         print(q)

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -15,6 +15,19 @@ try:
 except ImportError:
     parallel_sum = None
 
+if not hasattr(socket, "socketpair"):
+    def socketpair():
+        s1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s1.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s1.bind((socket.gethostname(), 8080))
+        s1.listen(1)
+        s2.connect((socket.gethostname(), 8080))
+        conn, addr = s1.accept()
+        return conn, s2
+
+    socket.socketpair = socketpair
+
 DELTA = 0.1
 ctx_loky = get_context("loky")
 HAVE_SEND_HANDLE = (sys.platform == "win32" or

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -140,7 +140,7 @@ class TestLokyBackend:
     def _test_connection(cls, conn):
         if hasattr(conn, "get"):
             conn = conn.get()
-        if type(conn) is socket.socket:
+        if hasattr(conn, "accept"):
             conn, addr = conn.accept()
             msg = conn.recv(2)
             conn.send(msg)

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -162,8 +162,9 @@ class TestLokyBackend:
         conn.close()
 
     @pytest.mark.skipif(
-        sys.platform == "win32" and sys.version_info[:2] < (3, 3),
-        reason="socket are not picklelable with python2.7 and multiprocessing"
+        sys.platform in ["win32"] and
+        sys.version_info[:2] < (3, 3),
+        reason="socket are not picklelable with python2.7 and vanilla"
         " ForkingPickler")
     def test_socket(self):
         server, client = socket.socketpair()

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -209,7 +209,7 @@ class TestLokyBackend:
 
         msg = b'42'
         rd.send_bytes(msg)
-        # assert rd.recv_bytes() == msg
+        assert rd.recv_bytes() == msg
 
         p.join()
         rd.close()
@@ -229,7 +229,7 @@ class TestLokyBackend:
 
         msg = b'42'
         rd.send_bytes(msg)
-        # assert rd.recv_bytes() == msg
+        assert rd.recv_bytes() == msg
 
         p.join()
         rd.close()

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -9,7 +9,7 @@ from time import sleep
 from multiprocessing import util
 from pickle import PicklingError, UnpicklingError
 
-from loky.reusable_executor import get_reusable_executor
+from loky import get_reusable_executor
 from loky.process_executor import BrokenExecutor, ShutdownExecutor
 from ._executor_mixin import ReusableExecutorMixin
 from .utils import TimingWrapper, id_sleep

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
      pytest-timeout
      psutil
      coverage
-     cython ; python_version < '3.7'
+     py{27,34,35,36}: cython
      cloudpickle ; python_version == '3.5'
      numpy ; python_version == '3.6'
      faulthandler ; python_version < '3.3'

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,18 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist = py27,py33,py34,py35,py36
-skip_missing_interpreters=True
 
 [testenv]
 passenv = NUMBER_OF_PROCESSORS
 deps =
      pytest
-     pytest-timeout
      psutil
      coverage
-     cython ; python_version < '3.7'
-     cloudpickle ; python_version == '3.5'
-     numpy ; python_version == '3.6'
+     numpy ; python_version == '3.5'
      faulthandler ; python_version < '3.3'
-whitelist_externals=
-     bash
 setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
-     PYENV={envname}
 commands =
-     # bash continuous_integration/build_test_ext.sh
-     # cd tests/_openmp
-     # COVERAGE_PROCESS_START=''
-     # python setup.py build_ext -i
-     # cd ../..
      python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-lv --maxfail=2 --timeout=10}
+     py.test {posargs:-lxv}
      coverage combine --append

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,30 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist = py27,py33,py34,py35,py36
+skip_missing_interpreters=True
 
 [testenv]
 passenv = NUMBER_OF_PROCESSORS
 deps =
      pytest
+     pytest-timeout
      psutil
      coverage
-     numpy ; python_version == '3.5'
+     cython ; python_version < '3.7'
+     cloudpickle ; python_version == '3.5'
+     numpy ; python_version == '3.6'
      faulthandler ; python_version < '3.3'
+whitelist_externals=
+     bash
 setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
+     PYENV={envname}
 commands =
+     # bash continuous_integration/build_test_ext.sh
+     # cd tests/_openmp
+     # COVERAGE_PROCESS_START=''
+     # python setup.py build_ext -i
+     # cd ../..
      python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-lxv}
+     py.test {posargs:-lv --maxfail=2 --timeout=10}
      coverage combine --append

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,11 @@ setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
      PYENV={envname}
 commands =
-     bash continuous_integration/build_test_ext.sh
+     # bash continuous_integration/build_test_ext.sh
+     # cd tests/_openmp
+     # COVERAGE_PROCESS_START=''
+     # python setup.py build_ext -i
+     # cd ../..
      python continuous_integration/install_coverage_subprocess_pth.py
      py.test {posargs:-lv --maxfail=2 --timeout=10}
      coverage combine --append

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ deps =
      pytest-timeout
      psutil
      coverage
-     cython
+     cython ; python_version < '3.7'
+     cloudpickle ; python_version == '3.5'
      numpy ; python_version == '3.6'
      faulthandler ; python_version < '3.3'
 whitelist_externals=


### PR DESCRIPTION
Now that we have a backport of the context object, we should reduce our code overhead and clean the backported files from any unnecessary code.