### PR TITLE
Use the "loky" context by default

### DIFF
--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -830,7 +830,7 @@ class ProcessPoolExecutor(_base.Executor):
         self._flags = _ExecutorFlags()
         self._queue_count = 0
         self._pending_work_items = {}
-        mp.util.debug('PoolProcessExecutor is setup')
+        mp.util.debug('ProcessPoolExecutor is setup')
 
     def _setup_queue(self, job_reducers, result_reducers):
         # Make the call queue slightly larger than the number of processes to

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -808,7 +808,7 @@ class ProcessPoolExecutor(_base.Executor):
             result_reducers = job_reducers
 
         # Parameters of this executor
-        self._ctx = context or get_context()
+        self._ctx = context or get_context('loky')
         mp.util.debug("using context {}".format(self._ctx))
         _check_max_detph(self._ctx)
 


### PR DESCRIPTION
Otherwise the unsafe "fork" context is used by default.