### PR TITLE
[MRG] Avoid module names as string

### DIFF
--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -143,7 +143,7 @@ class Popen(object):
             #     _mk_inheritable(fd)
 
             cmd_python = [sys.executable]
-            cmd_python += ['-m', 'loky.backend.popen_loky_posix']
+            cmd_python += ['-m', self.__module__]
             cmd_python += ['--name-process', str(process_obj.name)]
             cmd_python += ['--pipe',
                            str(reduction._mk_inheritable(child_r))]

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -64,8 +64,8 @@ class SemaphoreTracker(object):
                 fds_to_pass.append(sys.stderr.fileno())
             except Exception:
                 pass
-            cmd = ('from loky.backend.semaphore_tracker import main;'
-                   'main(%d)')
+
+            cmd = 'from {} import main; main(%d)'.format(main.__module__)
             r, w = os.pipe()
             try:
                 fds_to_pass.append(r)


### PR DESCRIPTION
This will make it easier and safer to do source code imports rewrite to
vendor loky in third-party libraries such as joblib and scikit-learn.

To be included in 1.1.3.