### PR TITLE
[MRG] ENH protect windows imports under POSIX

### DIFF
--- a/loky/backend/_win_reduction.py
+++ b/loky/backend/_win_reduction.py
@@ -11,16 +11,16 @@ import sys
 import socket
 from .reduction import register
 
-# Windows
-if sys.version_info[:2] < (3, 3):
-    from _multiprocessing import PipeConnection
-else:
-    import _winapi
 
-    from multiprocessing.connection import PipeConnection
+if sys.platform == 'win32':
+    if sys.version_info[:2] < (3, 3):
+        from _multiprocessing import PipeConnection
+    else:
+        import _winapi
+        from multiprocessing.connection import PipeConnection
 
-if sys.version_info[:2] >= (3, 4):
 
+if sys.version_info[:2] >= (3, 4) and sys.platform == 'win32':
     class DupHandle(object):
         def __init__(self, handle, access, pid=None):
             # duplicate handle for process with given pid
@@ -61,12 +61,13 @@ if sys.version_info[:2] >= (3, 4):
         return PipeConnection(handle, readable, writable)
     register(PipeConnection, reduce_pipe_connection)
 
-else:
+elif sys.platform == 'win32':
+    # Older Python versions
     from multiprocessing.reduction import reduce_pipe_connection
     register(PipeConnection, reduce_pipe_connection)
 
 
-if sys.version_info[:2] < (3, 3):
+if sys.version_info[:2] < (3, 3) and sys.platform == 'win32':
     from _multiprocessing import win32
     from multiprocessing.reduction import reduce_handle, rebuild_handle
     close = win32.CloseHandle

--- a/loky/backend/_win_wait.py
+++ b/loky/backend/_win_wait.py
@@ -8,47 +8,51 @@
 #
 
 import ctypes
+import sys
 from time import sleep
-from _subprocess import WaitForSingleObject, WAIT_OBJECT_0
-
-try:
-    from time import monotonic
-except ImportError:
-    # Backward old for crappy old Python that did not have cross-platform
-    # monotonic clock by default.
-
-    # TODO: do we want to add support for cygwin at some point? See:
-    # https://github.com/atdt/monotonic/blob/master/monotonic.py
-    GetTickCount64 = ctypes.windll.kernel32.GetTickCount64
-    GetTickCount64.restype = ctypes.c_ulonglong
-
-    def monotonic():
-        """Monotonic clock, cannot go backward."""
-        return GetTickCount64() / 1000.0
 
 
-def wait(handles, timeout=None):
-    """Backward compat for python2.7
+if sys.platform == 'win32' and sys.version_info[:2] < (3, 3):
+    from _subprocess import WaitForSingleObject, WAIT_OBJECT_0
 
-    This function wait for either:
-    * one connection is ready for read,
-    * one process handle has exited or got killed,
-    * timeout is reached. Note that this function has a precision of 2 msec.
-    """
-    if timeout is not None:
-        deadline = monotonic() + timeout
+    try:
+        from time import monotonic
+    except ImportError:
+        # Backward old for crappy old Python that did not have cross-platform
+        # monotonic clock by default.
 
-    while True:
-        # We cannot use select as in windows it only support sockets
-        ready = []
-        for h in handles:
-            if type(h) == int:
-                if WaitForSingleObject(h, 0) == WAIT_OBJECT_0:
-                    ready += [h]
-            elif h.poll(0):
-                ready.append(h)
-        if len(ready) > 0:
-            return ready
-        sleep(.001)
-        if timeout is not None and deadline - monotonic() <= 0:
-            return []
+        # TODO: do we want to add support for cygwin at some point? See:
+        # https://github.com/atdt/monotonic/blob/master/monotonic.py
+        GetTickCount64 = ctypes.windll.kernel32.GetTickCount64
+        GetTickCount64.restype = ctypes.c_ulonglong
+
+        def monotonic():
+            """Monotonic clock, cannot go backward."""
+            return GetTickCount64() / 1000.0
+
+    def wait(handles, timeout=None):
+        """Backward compat for python2.7
+
+        This function wait for either:
+        * one connection is ready for read,
+        * one process handle has exited or got killed,
+        * timeout is reached. Note that this function has a precision of 2
+          msec.
+        """
+        if timeout is not None:
+            deadline = monotonic() + timeout
+
+        while True:
+            # We cannot use select as in windows it only support sockets
+            ready = []
+            for h in handles:
+                if type(h) == int:
+                    if WaitForSingleObject(h, 0) == WAIT_OBJECT_0:
+                        ready += [h]
+                elif h.poll(0):
+                    ready.append(h)
+            if len(ready) > 0:
+                return ready
+            sleep(.001)
+            if timeout is not None and deadline - monotonic() <= 0:
+                return []

--- a/loky/backend/compat_win32.py
+++ b/loky/backend/compat_win32.py
@@ -1,51 +1,55 @@
 # flake8: noqa: F401
 import sys
 
-# Compat Popen
-if sys.version_info[:2] >= (3, 4):
-    from multiprocessing.popen_spawn_win32 import Popen
-else:
-    from multiprocessing.forking import Popen
+if sys.platform == "win32":
+    # Avoid import error by code introspection tools such as test runners
+    # trying to import this module while running on non-Windows systems.
 
-# wait compat
-if sys.version_info < (3, 3):
-    from ._win_wait import wait
-else:
-    from multiprocessing.connection import wait
-
-# Compat _winapi
-if sys.version_info[:2] >= (3, 4):
-    import _winapi
-else:
-    import os
-    import msvcrt
-    if sys.version_info[:2] < (3, 3):
-        import _subprocess as win_api
-        from _multiprocessing import win32
+    # Compat Popen
+    if sys.version_info[:2] >= (3, 4):
+        from multiprocessing.popen_spawn_win32 import Popen
     else:
-        import _winapi as win_api
+        from multiprocessing.forking import Popen
 
-    class _winapi:
-        CreateProcess = win_api.CreateProcess
+    # wait compat
+    if sys.version_info[:2] < (3, 3):
+        from ._win_wait import wait
+    else:
+        from multiprocessing.connection import wait
 
-        @staticmethod
-        def CreatePipe(*args):
-            rfd, wfd = os.pipe()
-            _current_process = win_api.GetCurrentProcess()
-            rhandle = win_api.DuplicateHandle(
-                _current_process, msvcrt.get_osfhandle(rfd), 
-                _current_process, 0, True,
-                win_api.DUPLICATE_SAME_ACCESS)
-            if sys.version_info[:2] < (3, 3):
-                rhandle = rhandle.Detach()
-            os.close(rfd)
-            return rhandle, wfd
+    # Compat _winapi
+    if sys.version_info[:2] >= (3, 4):
+        import _winapi
+    else:
+        import os
+        import msvcrt
+        if sys.version_info[:2] < (3, 3):
+            import _subprocess as win_api
+            from _multiprocessing import win32
+        else:
+            import _winapi as win_api
 
-        @staticmethod
-        def CloseHandle(h):
-            if sys.version_info[:2] < (3, 3):
-                if type(h) != int:
-                    h = h.Detach()
-                win32.CloseHandle(h)
-            else:
-                win_api.CloseHandle(h)
+        class _winapi:
+            CreateProcess = win_api.CreateProcess
+
+            @staticmethod
+            def CreatePipe(*args):
+                rfd, wfd = os.pipe()
+                _current_process = win_api.GetCurrentProcess()
+                rhandle = win_api.DuplicateHandle(
+                    _current_process, msvcrt.get_osfhandle(rfd),
+                    _current_process, 0, True,
+                    win_api.DUPLICATE_SAME_ACCESS)
+                if sys.version_info[:2] < (3, 3):
+                    rhandle = rhandle.Detach()
+                os.close(rfd)
+                return rhandle, wfd
+
+            @staticmethod
+            def CloseHandle(h):
+                if sys.version_info[:2] < (3, 3):
+                    if type(h) != int:
+                        h = h.Detach()
+                    win32.CloseHandle(h)
+                else:
+                    win_api.CloseHandle(h)

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('Command line parser')
     parser.add_argument('--pipe', type=int, required=True,
                         help='File handle for the pipe')
-    parser.add_argument('--semaphore', type=int, default=None,
+    parser.add_argument('--semaphore', type=int, required=True,
                         help='File handle name for the semaphore tracker')
     parser.add_argument('--name-process', type=str, default=None,
                         help='Identifier for debugging purpose')
@@ -187,17 +187,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     info = dict()
-    r = args.pipe
-    if sys.platform == 'win32':
-        import msvcrt
-        r = msvcrt.open_osfhandle(r, os.O_RDONLY)
-    else:
-        assert args.semaphore is not None
-        semaphore_tracker._semaphore_tracker._fd = args.semaphore
+    semaphore_tracker._semaphore_tracker._fd = args.semaphore
 
     exitcode = 1
     try:
-        with os.fdopen(r, 'rb') as from_parent:
+        with os.fdopen(args.pipe, 'rb') as from_parent:
             process.current_process()._inheriting = True
             try:
                 prep_data = pickle.load(from_parent)

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -176,15 +176,14 @@ class Popen(object):
 
 
 if __name__ == '__main__':
-
     import argparse
     parser = argparse.ArgumentParser('Command line parser')
-    parser.add_argument('--pipe', type=int, default=None,
-                        help='File handle numbers for the pipe')
+    parser.add_argument('--pipe', type=int, required=True,
+                        help='File handle for the pipe')
     parser.add_argument('--semaphore', type=int, default=None,
                         help='File handle name for the semaphore tracker')
     parser.add_argument('--name-process', type=str, default=None,
-                        help='Identifier for debuggging purpose')
+                        help='Identifier for debugging purpose')
 
     args = parser.parse_args()
 
@@ -194,10 +193,10 @@ if __name__ == '__main__':
         import msvcrt
         r = msvcrt.open_osfhandle(r, os.O_RDONLY)
     else:
+        assert args.semaphore is not None
         semaphore_tracker._semaphore_tracker._fd = args.semaphore
 
     exitcode = 1
-
     try:
         with os.fdopen(r, 'rb') as from_parent:
             process.current_process()._inheriting = True

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -1,13 +1,19 @@
 import os
 import sys
-import msvcrt
 
 from .context import get_spawning_popen, set_spawning_popen
 from . import spawn
 from . import reduction
 from multiprocessing import util
-from .compat_win32 import _winapi
-from .compat_win32 import Popen as _Popen
+
+if sys.platform == "win32":
+    # Avoid import error by code introspection tools such as test runners
+    # trying to import this module while running on non-Windows systems.
+    import msvcrt
+    from .compat_win32 import _winapi
+    from .compat_win32 import Popen as _Popen
+else:
+    _Popen = object
 
 if sys.version_info[:2] < (3, 3):
     from os import fdopen as open

--- a/loky/backend/semlock.py
+++ b/loky/backend/semlock.py
@@ -39,17 +39,18 @@ class timespec(ctypes.Structure):
     _fields_ = [("tv_sec", ctypes.c_long), ("tv_nsec", ctypes.c_long)]
 
 
-pthread = ctypes.CDLL(find_library('pthread'), use_errno=True)
-pthread.sem_open.restype = ctypes.c_void_p
-pthread.sem_close.argtypes = [ctypes.c_void_p]
-pthread.sem_wait.argtypes = [ctypes.c_void_p]
-pthread.sem_trywait.argtypes = [ctypes.c_void_p]
-pthread.sem_post.argtypes = [ctypes.c_void_p]
-pthread.sem_getvalue.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-pthread.sem_unlink.argtypes = [ctypes.c_char_p]
-if sys.platform != "darwin":
-    pthread.sem_timedwait.argtypes = [ctypes.c_void_p,
-                                      ctypes.POINTER(timespec)]
+if sys.platform != 'win32':
+    pthread = ctypes.CDLL(find_library('pthread'), use_errno=True)
+    pthread.sem_open.restype = ctypes.c_void_p
+    pthread.sem_close.argtypes = [ctypes.c_void_p]
+    pthread.sem_wait.argtypes = [ctypes.c_void_p]
+    pthread.sem_trywait.argtypes = [ctypes.c_void_p]
+    pthread.sem_post.argtypes = [ctypes.c_void_p]
+    pthread.sem_getvalue.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    pthread.sem_unlink.argtypes = [ctypes.c_char_p]
+    if sys.platform != "darwin":
+        pthread.sem_timedwait.argtypes = [ctypes.c_void_p,
+                                          ctypes.POINTER(timespec)]
 
 try:
     from threading import get_ident


### PR DESCRIPTION
When vendoring loky into joblib and then into scikit-learn some tools such as test runners or test_common of scikit-learn try to recursively import all the modules. Modules that import windows-only system tools subsequently fail.

While we could fix the introspection tools everywhere, I have the feeling it would be less intrusive to have loky modules protect their OS specific modules.

This PRs does so for windows specific imports under POSIX.