### PR TITLE
[WIP] actually test for 64 bit Python on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,10 +6,12 @@ environment:
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
+      PYTHON_ARCH_SUFFIX: ""
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
+      PYTHON_ARCH_SUFFIX: "-x64"
 matrix:
   fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,14 @@
 environment:
-  # There is no need to run the build for all the Python version /
-  # architectures combo as the generated joblib wheel is the same on all
-  # platforms (universal wheel).
-  # We run the tests on 2 different target platforms for testing purpose only.
+  # The test script uses tox to run the tests on all supported
+  # Python versions sequentially.
+  # We run it once per architecture (32 bit vs 64 bit).
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 matrix:
   fast_finish: true

--- a/continuous_integration/appveyor/runtests.ps1
+++ b/continuous_integration/appveyor/runtests.ps1
@@ -8,6 +8,8 @@ $VERSION=(27, 33, 36)
 function TestPythonVersions () {
     Write-Host $PYTHON
     ForEach($ver in $VERSION){
+        $env:TOXPYTHON = "C:\Python$ver$env:PYTHON_ARCH_SUFFIX\python.exe"
+        Write-Host $env:TOXPYTHON
         python ./continuous_integration/appveyor/tox -e py$ver -- -vlx --timeout=30
         If( $LASTEXITCODE -ne 0){
             Exit 1

--- a/loky/backend/compat_win32.py
+++ b/loky/backend/compat_win32.py
@@ -1,5 +1,6 @@
 # flake8: noqa: F401
 import sys
+import numbers
 
 if sys.platform == "win32":
     # Avoid import error by code introspection tools such as test runners
@@ -47,8 +48,11 @@ if sys.platform == "win32":
 
             @staticmethod
             def CloseHandle(h):
+                if isinstance(h, numbers.Integral):
+                    # Cast long to int for 64-bit Python 2.7 under Windows
+                    h = int(h)
                 if sys.version_info[:2] < (3, 3):
-                    if type(h) != int:
+                    if not isinstance(h, int):
                         h = h.Detach()
                     win32.CloseHandle(h)
                 else:

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -494,7 +494,10 @@ def _queue_management_worker(executor_reference,
         # Wait for a result to be ready in the result_queue while checking
         # that worker process are still running. If a worker process
         while not wakeup.get_and_unset():
-            worker_sentinels = [p.sentinel for p in list(processes.values())]
+            # Force cast long to int when running 64-bit Python 2.7 under
+            # Windows
+            worker_sentinels = [int(p.sentinel)
+                                for p in list(processes.values())]
             if len(worker_sentinels) == 0:
                 wakeup.set()
             ready = wait([result_reader] + worker_sentinels,

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -387,8 +387,8 @@ class TestLokyBackend:
         with pytest.raises(ValueError):
             p.sentinel
         p.start()
-        sentinel = p.sentinel
-        assert isinstance(sentinel, int)
+        # Cast long to int for 64-bit Python 2.7 under Windows
+        sentinel = int(p.sentinel)
         assert not wait_for_handle(sentinel, timeout=0.0)
         event.set()
         p.join()
@@ -406,7 +406,8 @@ class TestLokyBackend:
         with pytest.raises(ValueError):
             p.sentinel
         p.start()
-        sentinel = p.sentinel
+        # Cast long to int for 64-bit Python 2.7 under Windows
+        sentinel = int(p.sentinel)
         assert isinstance(sentinel, int)
         assert not wait([sentinel], timeout=0.0)
         assert wait([sentinel], timeout=5), (p.exitcode)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,12 @@ envlist = py27,py33,py34,py35,py36
 skip_missing_interpreters=True
 
 [testenv]
+basepython =
+     py27: {env:TOXPYTHON:python2.7}
+     py33: {env:TOXPYTHON:python3.3}
+     py34: {env:TOXPYTHON:python3.4}
+     py35: {env:TOXPYTHON:python3.5}
+     py36: {env:TOXPYTHON:python3.6}
 passenv = NUMBER_OF_PROCESSORS
 deps =
      pytest

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ setenv =
      PYENV={envname}
      LOKY_MAX_DEPTH=3
 commands =
+     python -c "import struct; print('platform: %d' % (8 * struct.calcsize('P')))"
      python continuous_integration/install_coverage_subprocess_pth.py
      py.test {posargs:-lv --maxfail=2 --timeout=10}
      coverage combine --append


### PR DESCRIPTION
and fix copy-pasted comment in appveyor.yml.

Since we use tox the Python version is not important, just the platform is. However we don't want to give the impression that legacy Python 2.7 is a reasonable default nowadays :)

The issue was revealed by the scikit-learn CI tests: https://github.com/scikit-learn/scikit-learn/pull/9486