### PR TITLE
FIX run loky from tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,13 +21,15 @@ deps =
      numpy ; python_version == '3.6'
      faulthandler ; python_version < '3.3'
 whitelist_externals=
-     bash
+     cp
 setenv =
      COVERAGE_PROCESS_START={toxinidir}/.coveragerc
      PYENV={envname}
      LOKY_MAX_DEPTH=3
+changedir = {envdir}/tmp
 commands =
-     python -c "import struct; print('platform: %d' % (8 * struct.calcsize('P')))"
-     python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-lv --maxfail=2 --timeout=10}
-     coverage combine --append
+    cp -r {toxinidir}/tests {envdir}/tmp/tests
+    python {toxinidir}/continuous_integration/install_coverage_subprocess_pth.py
+    python -c "import struct; print('platform: %d' % (8 * struct.calcsize('P')))"
+    pytest {posargs:-lv --maxfail=2 --timeout=10}
+    coverage combine --append


### PR DESCRIPTION
This is an alternative solution to #85 

Here, we just copy the test directory in tox and run from it, so it avoids adding the repo in the `PYTHONPATH`.