### PR TITLE
[MRG] ensure exception compatibility with concurrent.futures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### 1.2 - (development)
+
+- Rename loky.BrokenExecutor as loky.BrokenProcessPool and subclass
+  concurrent.futures.process.BrokenProcessPool when available to make
+  except statements forward compatible.
+
+
 ### 1.1.4 - 08/08/2017 - Bug fix release
 
 - Fix crash for 64-bit Python under Windows.

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -77,6 +77,12 @@ from .backend.compat import wait, PicklingError
 from .backend.queues import Queue, SimpleQueue
 from .backend.utils import flag_current_thread_clean_exit, is_crashed
 
+try:
+    from concurrent.futures.process import BrokenProcessPool as _BPPException
+except ImportError:
+    _BPPException = RuntimeError
+
+
 # Compatibility for python2.7
 if sys.version_info[0] == 2:
     ProcessLookupError = OSError
@@ -748,7 +754,7 @@ class LokyRecursionError(RuntimeError):
     """
 
 
-class BrokenProcessPool(RuntimeError):
+class BrokenProcessPool(_BPPException):
     """
     Raised when a process in a ProcessPoolExecutor terminated abruptly
     while a future was in the running state.

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -551,3 +551,14 @@ def test_interactively_define_executor_no_main():
         check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10)
     finally:
         os.unlink(filename)
+
+
+def test_compat_with_concurrent_futures_exception():
+    # It should be possible to use a loky process pool executor as a dropin
+    # replacement for a ProcessPoolExecutor, including when catching
+    # exceptions:
+    pytest.importorskip('concurrent.futures')
+    from concurrent.futures.process import BrokenProcessPool as BPPExc
+
+    with pytest.raises(BPPExc):
+        get_reusable_executor(max_workers=2).submit(crash).result()


### PR DESCRIPTION
This is to ensure that code written for `concurrent.futures` will still work when using the `ProcessPoolExecutor` implementation from loky.