### PR TITLE
FIX full queue exception at shutdown

### DIFF
--- a/loky/backend/queues.py
+++ b/loky/backend/queues.py
@@ -18,6 +18,7 @@ import threading
 from multiprocessing import util
 from multiprocessing import connection
 from multiprocessing.synchronize import SEM_VALUE_MAX
+from multiprocessing.queues import Full
 from multiprocessing.queues import _sentinel, Queue as mp_Queue
 from multiprocessing.queues import SimpleQueue as mp_SimpleQueue
 
@@ -25,7 +26,7 @@ from .reduction import CustomizableLokyPickler
 from .context import assert_spawning, get_context
 
 
-__all__ = ['Queue', 'SimpleQueue']
+__all__ = ['Queue', 'SimpleQueue', 'Full']
 
 
 class Queue(mp_Queue):

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -74,7 +74,7 @@ from . import _base
 from .backend import get_context
 from .backend.compat import queue
 from .backend.compat import wait, PicklingError
-from .backend.queues import Queue, SimpleQueue
+from .backend.queues import Queue, SimpleQueue, Full
 from .backend.utils import _flag_current_thread_clean_exit, _is_crashed
 
 try:
@@ -489,7 +489,7 @@ def _queue_management_worker(executor_reference,
             for i in range(n_workers_to_stop - n_sentinels_sent):
                 try:
                     call_queue.put_nowait(None)
-                except Queue.Full:
+                except Full:
                     break
                 n_sentinels_sent += 1
             with processes_management_lock:


### PR DESCRIPTION
Fix for the following exceptions fond in joblib test logs under Python 3.6:

```
Exception in thread QueueManagerThread:
Traceback (most recent call last):
  File "/volatile/ogrisel/code/joblib/joblib/externals/loky/process_executor.py", line 491, in shutdown_all_workers
    call_queue.put_nowait(None)
  File "/usr/lib/python3.6/multiprocessing/queues.py", line 129, in put_nowait
    return self.put(obj, False)
  File "/usr/lib/python3.6/multiprocessing/queues.py", line 83, in put
    raise Full
queue.Full

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/volatile/ogrisel/code/joblib/joblib/externals/loky/process_executor.py", line 652, in _queue_management_worker
    shutdown_all_workers()
  File "/volatile/ogrisel/code/joblib/joblib/externals/loky/process_executor.py", line 492, in shutdown_all_workers
    except Queue.Full:
AttributeError: type object 'Queue' has no attribute 'Full'
```