### PR TITLE
ENH safe terminate for nested processes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### 2.2.0 - in development
 
+- Fix terminate for nested processes
+
 ### 2.1.1 - 2018-04-13 - Bug fix release
 
 - Fix interpreter shutdown

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -65,7 +65,10 @@ def _recursive_terminate(pid):
             )
         except subprocess.CalledProcessError as e:
             # `ps` returns 1 when no child process has been found
-            children_pids = b''
+            if e.returncode == 1:
+                children_pids = b''
+            else:
+                raise
 
         # Decode the result, split the cpid and remove the trailing line
         children_pids = children_pids.decode().split('\n')[:-1]

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -13,11 +13,11 @@ def _flag_current_thread_clean_exit():
     thread._clean_exit = True
 
 
-def safe_terminate(process):
+def recursive_terminate(process):
     """Terminate a process and its children.
     """
     try:
-        _safe_terminate(process.pid)
+        _recursive_terminate(process.pid)
         process.join()
     except OSError as e:
         import traceback
@@ -31,7 +31,7 @@ def safe_terminate(process):
         process.join()
 
 
-def _safe_terminate(pid):
+def _recursive_terminate(pid):
     """Terminate the children of a process before killing this process.
     """
 
@@ -66,7 +66,7 @@ def _safe_terminate(pid):
         children_pids = children_pids.decode().split('\n')[:-1]
         for cpid in children_pids:
             cpid = int(cpid)
-            _safe_terminate(cpid)
+            _recursive_terminate(cpid)
 
         try:
             os.kill(pid, signal.SIGTERM)

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -1,7 +1,55 @@
+import os
+import sys
+import errno
+import signal
 import threading
+import subprocess
 
 
 def _flag_current_thread_clean_exit():
     """Put a ``_clean_exit`` flag on the current thread"""
     thread = threading.current_thread()
     thread._clean_exit = True
+
+
+def safe_terminate(process):
+    """Terminate a process and its children.
+    """
+
+    _safe_terminate(process.pid)
+    process.join()
+
+
+def _safe_terminate(pid):
+    """Terminate the children of a process before killing this process.
+    """
+
+    if sys.platform == "win32":
+        # On windows, the taskkill function with option `/T` terminate a given
+        # process pid and its children.
+        subprocess.check_output(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            stderr=None)
+    else:
+        try:
+            children_pids = subprocess.check_output(
+                ["ps", "-o", "pid=", "--ppid", str(pid)],
+                stderr=None
+            )
+        except subprocess.CalledProcessError as e:
+            # `ps` returns 1 when no child process has been found
+            children_pids = b''
+
+        # Decode the result, split the cpid and remove the trailing line
+        children_pids = children_pids.decode().split('\n')[:-1]
+        for cpid in children_pids:
+            cpid = int(cpid)
+            _safe_terminate(cpid)
+
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError as e:
+            # if OSError is raised with [Errno 3] no such process, the process
+            # is already terminated, else, raise the error
+            if e.errno != errno.ESRCH:
+                raise

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -76,7 +76,7 @@ from .backend.compat import queue
 from .backend.compat import wait
 from .backend.context import cpu_count
 from .backend.queues import Queue, SimpleQueue, Full
-from .backend.utils import safe_terminate
+from .backend.utils import recursive_terminate
 
 try:
     from concurrent.futures.process import BrokenProcessPool as _BPPException
@@ -595,7 +595,7 @@ def _queue_management_worker(executor_reference,
                 _, p = processes.popitem()
                 mp.util.debug('terminate process {}'.format(p.name))
                 try:
-                    safe_terminate(p)
+                    recursive_terminate(p)
                 except ProcessLookupError:  # pragma: no cover
                     pass
 
@@ -668,7 +668,7 @@ def _queue_management_worker(executor_reference,
                 # locks may be in a dirty state and block forever.
                 while processes:
                     _, p = processes.popitem()
-                    safe_terminate(p)
+                    recursive_terminate(p)
                 shutdown_all_workers()
                 return
             # Since no new work items can be added, it is safe to shutdown

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -76,6 +76,7 @@ from .backend.compat import queue
 from .backend.compat import wait
 from .backend.context import cpu_count
 from .backend.queues import Queue, SimpleQueue, Full
+from .backend.utils import safe_terminate
 
 try:
     from concurrent.futures.process import BrokenProcessPool as _BPPException
@@ -594,8 +595,7 @@ def _queue_management_worker(executor_reference,
                 _, p = processes.popitem()
                 mp.util.debug('terminate process {}'.format(p.name))
                 try:
-                    p.terminate()
-                    p.join()
+                    safe_terminate(p)
                 except ProcessLookupError:  # pragma: no cover
                     pass
 
@@ -668,8 +668,7 @@ def _queue_management_worker(executor_reference,
                 # locks may be in a dirty state and block forever.
                 while processes:
                     _, p = processes.popitem()
-                    p.terminate()
-                    p.join()
+                    safe_terminate(p)
                 shutdown_all_workers()
                 return
             # Since no new work items can be added, it is safe to shutdown

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -680,9 +680,9 @@ def wait_for_handle(handle, timeout):
     return wait([handle], timeout)
 
 
-def _run_netesed_delayed(depth, delay, event):
+def _run_nested_delayed(depth, delay, event):
     if depth > 0:
-        p = multiprocessing.Process(target=_run_netesed_delayed,
+        p = multiprocessing.Process(target=_run_nested_delayed,
                                     args=(depth - 1, delay, event))
         p.start()
         p.join()
@@ -694,15 +694,15 @@ def _run_netesed_delayed(depth, delay, event):
 
 def test_recursive_terminate():
     event = multiprocessing.Event()
-    p = multiprocessing.Process(target=_run_netesed_delayed,
+    p = multiprocessing.Process(target=_run_nested_delayed,
                                 args=(4, 1000, event))
     p.start()
 
     # Wait for all the processes to be launched
     if not event.wait(10):
         recursive_terminate(p)
-        raise RuntimeError("test_recursive_terminate was not able to launch all "
-                           "nested processes.")
+        raise RuntimeError("test_recursive_terminate was not able to launch "
+                           "all nested processes.")
 
     children = psutil.Process(pid=p.pid).children(recursive=True)
     recursive_terminate(p)
@@ -710,4 +710,4 @@ def test_recursive_terminate():
     # The process can take some time finishing so we should wait up to 5s
     gone, alive = psutil.wait_procs(children, timeout=5)
     msg = "Should be no descendent left but found:\n{}"
-    assert len(alive) == 0, msg.format(children)
+    assert len(alive) == 0, msg.format(alive)

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -709,5 +709,5 @@ def test_recursive_terminate():
 
     # The process can take some time finishing so we should wait up to 5s
     gone, alive = psutil.wait_procs(children, timeout=5)
-    msg = "Should be no descendent left but found:\n{}"
+    msg = "Should be no descendant left but found:\n{}"
     assert len(alive) == 0, msg.format(alive)

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -11,7 +11,7 @@ from tempfile import mkstemp
 
 from loky.backend import get_context
 from loky.backend.compat import wait
-from loky.backend.utils import safe_terminate
+from loky.backend.utils import recursive_terminate
 from .utils import TimingWrapper, check_subprocess_call
 
 try:
@@ -70,7 +70,7 @@ class TestLokyBackend:
         """Clean up the test environment from any remaining subprocesses.
         """
         for child_process in cls.active_children():
-            safe_terminate(child_process)
+            recursive_terminate(child_process)
 
     def test_current(self):
 
@@ -692,7 +692,7 @@ def _run_netesed_delayed(depth, delay, event):
     time.sleep(delay)
 
 
-def test_safe_terminate():
+def test_recursive_terminate():
     event = multiprocessing.Event()
     p = multiprocessing.Process(target=_run_netesed_delayed,
                                 args=(4, 1000, event))
@@ -700,12 +700,12 @@ def test_safe_terminate():
 
     # Wait for all the processes to be launched
     if not event.wait(10):
-        safe_terminate(p)
-        raise RuntimeError("test_safe_terminate was not able to launch all "
+        recursive_terminate(p)
+        raise RuntimeError("test_recursive_terminate was not able to launch all "
                            "nested processes.")
 
     children = psutil.Process(pid=p.pid).children(recursive=True)
-    safe_terminate(p)
+    recursive_terminate(p)
 
     # The process can take some time finishing so we should wait up to 5s
     gone, alive = psutil.wait_procs(children, timeout=5)


### PR DESCRIPTION
This should avoid leaving unattended processes, which freeze the shutting down process of the python interpreter.