### PR TITLE
Use psutil to terminate processes when available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   before accepting new tasks. This protection is only active when psutil
   is installed.
 
+- psutil is now a soft-dependency of loky: it is used to recursively
+  terminate children processes when available but there is a fallback
+  for windows and all unices with pgrep installed otherwise.
+
 ### 2.1.4 - 2018-06-29 - Bug fix release
 
 - Fix win32 failure to kill worker process with taskkill returning 255

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -5,6 +5,10 @@ import signal
 import warnings
 import threading
 import subprocess
+try:
+    import psutil
+except ImportError:
+    psutil = None
 
 
 def _flag_current_thread_clean_exit():
@@ -13,17 +17,42 @@ def _flag_current_thread_clean_exit():
     thread._clean_exit = True
 
 
-def recursive_terminate(process):
+def recursive_terminate(process, use_psutil=True):
+    if use_psutil and psutil is not None:
+        _recursive_terminate_with_psutil(process)
+    else:
+        _recursive_terminate_without_psutil(process)
+
+
+def _recursive_terminate_with_psutil(process, retries=5):
+    try:
+        psutil_process = psutil.Process(process.pid)
+    except psutil._exceptions.NoSuchProcess:
+        return
+
+    children = psutil_process.children(recursive=True)
+    for child in children:
+        try:
+            child.terminate()
+        except psutil._exceptions.NoSuchProcess:
+            pass
+
+    gone, still_alive = psutil.wait_procs(children, timeout=5)
+    for p in still_alive:
+        p.kill()
+
+    process.terminate()
+    process.join()
+
+
+def _recursive_terminate_without_psutil(process):
     """Terminate a process and its descendants.
     """
     try:
         _recursive_terminate(process.pid)
     except OSError as e:
-        import traceback
-        tb = traceback.format_exc()
-        warnings.warn("Failure in child introspection on this platform. You "
-                      "should report it on https://github.com/tomMoral/loky "
-                      "with the following traceback\n{}".format(tb))
+        warnings.warn("Failed to kill subprocesses on this platform. Please"
+                      "install psutil: https://github.com/giampaolo/psutil")
         # In case we cannot introspect the children, we fall back to the
         # classic Process.terminate.
         process.terminate()

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
     ],
     cmdclass=cmdclass,
     platforms='any',
-    install_requires=['cloudpickle'],
-    tests_require=['pytest', 'psutil'],
-
+    install_requires=['cloudpickle', 'psutil'],
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
This is useful on POSIX systems where pgrep is not installed such
as minimal docker images for instance.

The issue was found by @yarikoptic on the debian build system.