### PR TITLE
 ENH use cloudpickle wrapper for initializer 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ### 2.2.1.dev0 - in development
 
+- Fix pickling logic in loky. Now the serialization is consistent
+  between initializer and tasks. Also fixes the logic behind the
+  environment variable `LOKY_PICKLER`.
 - Fix deadlock when large objects are sent to workers.
 
 ### 2.2.0 - 2018-08-01 - Release Highlights

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -4,3 +4,21 @@ API Reference
 
 .. automodule:: loky
     :members: get_reusable_executor
+
+
+Task & results serialization
+----------------------------
+
+To share function definition across multiple python processes, it is necessary to rely on a serialization protocol. The standard protocol in python is :mod:`pickle` but its default implementation in the standard library has several limitations. For instance, it cannot serialize functions which are defined interactively or in the :code:`__main__` module.
+
+To avoid this limitation, :mod:`loky` relies on |cloudpickle| when it is present. |cloudpickle| is a fork of the pickle protocol which allows the serialization of a greater number of objects and it can be installed using :code:`pip install cloudpickle`. As this library is slower than the :mod:`pickle` module in the standard library, by default, :mod:`loky` uses it only to serialize objects which are detected to be in the :code:`__main__` module.
+
+There is two way to temper with the serialization in :mod:`loky`:
+
+- Using the arguments :code:`job_reducers` and :code:`result_reducers`, it is possible to register custom reducers for the serialization process.
+- Setting the variable :code:`LOKY_PICKLER` to an available and valid serialization module. This module must present a valid :code:`Pickler` object. Setting the environment variable :code:`LOKY_PICKER=cloudpickle` will force :mod:`loky` to serialize everything with |cloudpickle| instead of just serializing the object detected to be in the :code:`__main__` module.
+
+
+.. |cloudpickle| raw:: html
+
+    <a href="https://github.com/cloudpipe/cloudpickle"><code>cloudpickle</code></a>

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,3 @@
+blockquote ul{
+    font-size: 14px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -122,13 +122,13 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 html_sidebars = {
-#    '**': [
-#        'about.html',
-#        'navigation.html',
-#        'relations.html',  # needs 'show_related': True theme option to display
-#        'searchbox.html',
-#        'donate.html',
-#    ]
+    # '**': [
+    #    'about.html',
+    #    'navigation.html',
+    #    'relations.html',  # needs 'show_related': True theme option to display
+    #    'searchbox.html',
+    #    'donate.html',
+   # ]
 }
 
 
@@ -207,5 +207,8 @@ sphinx_gallery_conf = {
     'doc_module': ('loky')
 }
 
-intersphinx_mapping = {'python' : ('https://docs.python.org/3', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
+
+def setup(app):
+    app.add_stylesheet("custom.css")

--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -30,7 +30,12 @@ if sys.version_info[:2] >= (3, 4):
             warnings.warn("`fork` start method should not be used with `loky` "
                           "as it does not respect POSIX. Try using `spawn` or "
                           "`loky` instead.", UserWarning)
-        return get_mp_context(method)
+        try:
+            return get_mp_context(method)
+        except ValueError:
+            raise ValueError("Unknown context '{}'. Value should be in {{"
+                             "'loky', 'loky_init_main', 'spawn', 'forkserver'"
+                             "}}.".format(method))
 
 else:
     METHODS = ['loky', 'loky_init_main']

--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -35,7 +35,7 @@ def _recursive_terminate_with_psutil(process, retries=5):
     for child in children[::-1]:
         try:
             child.kill()
-        except psutil.NoSuchProcess as e:
+        except psutil.NoSuchProcess:
             pass
 
     process.terminate()

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -1,10 +1,16 @@
+import os
+import inspect
+from functools import partial
 
+from .backend import LOKY_PICKLER
 
 try:
     from cloudpickle import dumps, loads
-    import inspect
-    from functools import partial
+    cloudpickle = True
+except ImportError:
+    cloudpickle = False
 
+if not LOKY_PICKLER and cloudpickle:
     wrap_cache = dict()
 
     class CloudpickledObjectWrapper(object):
@@ -42,6 +48,6 @@ try:
             wrap_cache[obj] = wrapped_obj
         return wrapped_obj
 
-except ImportError:
+else:
     def _wrap_non_picklable_objects(obj):
         return obj

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -1,0 +1,47 @@
+
+
+try:
+    from cloudpickle import dumps, loads
+    import inspect
+    from functools import partial
+
+    wrap_cache = dict()
+
+    class CloudpickledObjectWrapper(object):
+        def __init__(self, obj):
+            self.pickled_obj = dumps(obj)
+
+        def __reduce__(self):
+            return loads, (self.pickled_obj,)
+
+    def _wrap_non_picklable_objects(obj):
+        need_wrap = "__main__" in getattr(obj, "__module__", "")
+        if isinstance(obj, partial):
+            return partial(
+                _wrap_non_picklable_objects(obj.func),
+                *[_wrap_non_picklable_objects(a) for a in obj.args],
+                **{k: _wrap_non_picklable_objects(v)
+                   for k, v in obj.keywords.items()}
+            )
+        if callable(obj):
+            # Need wrap if the object is a function defined in a local scope of
+            # another function.
+            func_code = getattr(obj, "__code__", "")
+            need_wrap |= getattr(func_code, "co_flags", 0) & inspect.CO_NESTED
+
+            # Need wrap if the obj is a lambda expression
+            func_name = getattr(obj, "__name__", "")
+            need_wrap |= "<lambda>" in func_name
+
+        if not need_wrap:
+            return obj
+
+        wrapped_obj = wrap_cache.get(obj)
+        if wrapped_obj is None:
+            wrapped_obj = CloudpickledObjectWrapper(obj)
+            wrap_cache[obj] = wrapped_obj
+        return wrapped_obj
+
+except ImportError:
+    def _wrap_non_picklable_objects(obj):
+        return obj


### PR DESCRIPTION
Consistently serialize function from `__main__` with `cloudpickle` when it is available.

Fix #146 