### PR TITLE
Fix private  _pickle import

### DIFF
--- a/loky/backend/compat.py
+++ b/loky/backend/compat.py
@@ -9,10 +9,10 @@ import sys
 
 if sys.version_info[:2] >= (3, 3):
     import queue
-    from _pickle import PicklingError
 else:
     import Queue as queue
-    from pickle import PicklingError
+
+from pickle import PicklingError
 
 if sys.version_info >= (3, 4):
     from multiprocessing.process import BaseProcess


### PR DESCRIPTION
Closes https://github.com/tomMoral/loky/issues/157

`import _pickle` accesses a private CPython module and consequently this fails on PyPy.
