### PR TITLE
Add support for PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: TOXENV="py36"
     - python: "3.7-dev"
       env: TOXENV="py37" RUN_MEMORY="true"
+    - python: "pypy3.5"
+      env: TOXENV="pypy3"
     - python: "3.6"
       env: TOXENV="py36" JOBLIB_TESTS="true"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
     - LOKY_MAX_DEPTH=3
 matrix:
   include:
+    - python: "pypy3.5"
+      env: TOXENV="pypy3"
     - python: 2.7
       env: TOXENV="py27"
     - python: 3.4
@@ -22,8 +24,6 @@ matrix:
       env: TOXENV="py36"
     - python: "3.7-dev"
       env: TOXENV="py37" RUN_MEMORY="true"
-    - python: "pypy3.5"
-      env: TOXENV="pypy3"
     - python: "3.6"
       env: TOXENV="py36" JOBLIB_TESTS="true"
     - os: osx

--- a/continuous_integration/travis/runtests.sh
+++ b/continuous_integration/travis/runtests.sh
@@ -28,7 +28,7 @@ if [ "$JOBLIB_TESTS" = "true" ]; then
 else
     # Run the tests and collect trace coverage data both in the subprocesses
     # and its subprocesses.
-    PYTEST_ARGS="-vl --timeout=30 --maxfail=5"
+    PYTEST_ARGS="-vl --timeout=60 --maxfail=5"
     if [ "$RUN_MEMORY" != "true" ]; then
         PYTEST_ARGS="$PYTEST_ARGS --skip-high-memory"
     fi

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -181,12 +181,13 @@ register(type(_C().f), _reduce_method)
 register(type(_C.h), _reduce_method)
 
 
-def _reduce_method_descriptor(m):
-    return getattr, (m.__objclass__, m.__name__)
+if sys.implementation.name != 'pypy':
+    # PyPy uses functions instead of method_descriptors and wrapper_descriptors
+    def _reduce_method_descriptor(m):
+        return getattr, (m.__objclass__, m.__name__)
 
-
-register(type(list.append), _reduce_method_descriptor)
-register(type(int.__add__), _reduce_method_descriptor)
+    register(type(list.append), _reduce_method_descriptor)
+    register(type(int.__add__), _reduce_method_descriptor)
 
 
 # Make partial func pickable

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -181,7 +181,7 @@ register(type(_C().f), _reduce_method)
 register(type(_C.h), _reduce_method)
 
 
-if sys.implementation.name != 'pypy':
+if not hasattr(sys, "pypy_version_info"):
     # PyPy uses functions instead of method_descriptors and wrapper_descriptors
     def _reduce_method_descriptor(m):
         return getattr, (m.__objclass__, m.__name__)

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -422,6 +422,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             result_queue.put(_ResultItem(call_item.work_id, exception=exc))
         else:
             _sendback_result(result_queue, call_item.work_id, result=r)
+            del r
 
         # Free the resource as soon as possible, to avoid holding onto
         # open files or shared memory that is not needed anymore

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -209,8 +209,9 @@ class ExecutorShutdownTest:
         t_deadline = time.time() + 1
         while executor_reference() is not None and time.time() < t_deadline:
             if IS_PYPY:
-                # XXX: this is only required under PyPy for some unknown
-                # reason:
+                # PyPy can delay __del__ calls and GC compared to CPython.
+                # To ensure that this test pass without waiting too long we
+                # need an explicit GC.
                 gc.collect()
             time.sleep(0.001)
         assert executor_reference() is None

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -47,6 +47,9 @@ else:
     from concurrent import futures
 
 
+IS_PYPY = hasattr(sys, "pypy_version_info")
+
+
 def create_future(state=PENDING, exception=None, result=None):
     f = Future()
     f._state = state
@@ -205,7 +208,7 @@ class ExecutorShutdownTest:
         # reference when we deleted self.executor.
         t_deadline = time.time() + 1
         while executor_reference() is not None and time.time() < t_deadline:
-            if sys.implementation.name == 'pypy':
+            if IS_PYPY:
                 # XXX: this is only required under PyPy for some unknown
                 # reason:
                 gc.collect()
@@ -248,7 +251,7 @@ class ExecutorShutdownTest:
         executor_reference = weakref.ref(self.executor)
         self.executor = None
 
-        if sys.implementation.name == 'pypy':
+        if IS_PYPY:
             gc.collect()
 
         # Make sure that there is not other reference to the executor object.
@@ -290,7 +293,7 @@ class ExecutorShutdownTest:
         queue_management_thread = executor._queue_management_thread
         processes = executor._processes
         del executor
-        if sys.implementation.name == 'pypy':
+        if IS_PYPY:
             gc.collect()
 
         queue_management_thread.join()
@@ -535,7 +538,7 @@ class ExecutorTest:
 
         collected = False
         for i in range(5):
-            if sys.implementation.name == 'pypy':
+            if IS_PYPY:
                 gc.collect()
             collected = collect.wait(timeout=1.0)
             if collected:

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -143,7 +143,7 @@ class ExecutorShutdownTest:
                                n_jobs=n_jobs,
                                tempdir=tempdir.replace("\\", "/"))
             stdout, stderr = check_subprocess_call(
-                [sys.executable, "-c", code], timeout=10)
+                [sys.executable, "-c", code], timeout=55)
 
             # On OSX, remove UserWarning for broken semaphores
             if sys.platform == "darwin":
@@ -685,7 +685,7 @@ class ExecutorTest:
                 patience -= 1
                 time.sleep(0.01)
 
-    @pytest.mark.timeout(50 if sys.platform == "win32" else 25)
+    @pytest.mark.timeout(60)
     def test_worker_timeout(self):
         self.executor.shutdown(wait=True)
         self.check_no_running_workers(patience=5)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -253,6 +253,8 @@ class ExecutorShutdownTest:
         self.executor = None
 
         if IS_PYPY:
+            # Object deletion and garbage collection can be delayed under PyPy.
+            time.sleep(1.)
             gc.collect()
 
         # Make sure that there is not other reference to the executor object.
@@ -295,6 +297,8 @@ class ExecutorShutdownTest:
         processes = executor._processes
         del executor
         if IS_PYPY:
+            # Object deletion and garbage collection can be delayed under PyPy.
+            time.sleep(1.)
             gc.collect()
 
         queue_management_thread.join()

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -7,7 +7,7 @@ from ._executor_mixin import ExecutorMixin
 
 if (sys.version_info[:2] > (3, 3)
         and sys.platform != "win32"
-        and sys.implementation.name != 'pypy'):
+        and not hasattr(sys, "pypy_version_info")):
     # XXX: the forkserver backend is broken with pypy3.
 
     class ProcessPoolForkserverMixin(ExecutorMixin):

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -5,7 +5,11 @@ from loky.backend import get_context
 from ._executor_mixin import ExecutorMixin
 
 
-if sys.version_info[:2] > (3, 3) and sys.platform != "win32":
+if (sys.version_info[:2] > (3, 3)
+        and sys.platform != "win32"
+        and sys.implementation.name != 'pypy'):
+    # XXX: the forkserver backend is broken with pypy3.
+
     class ProcessPoolForkserverMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('forkserver')

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -6,7 +6,7 @@ from ._executor_mixin import ExecutorMixin
 
 
 if (sys.version_info[:2] > (3, 3)
-        and sys.implementation.name != 'pypy'):
+        and not hasattr(sys, "pypy_version_info")):
     class ProcessPoolSpawnMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('spawn')

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -5,7 +5,8 @@ from loky.backend import get_context
 from ._executor_mixin import ExecutorMixin
 
 
-if sys.version_info[:2] > (3, 3):
+if (sys.version_info[:2] > (3, 3)
+        and sys.implementation.name != 'pypy'):
     class ProcessPoolSpawnMixin(ExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('spawn')

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27, py34, py35, py36, py37, pypy3
 skip_missing_interpreters=True
 
 [testenv]
@@ -13,6 +13,7 @@ basepython =
      py35: {env:TOXPYTHON:python3.5}
      py36: {env:TOXPYTHON:python3.6}
      py37: {env:TOXPYTHON:python3.7}
+     pypy3: {env:TOXPYTHON:pypy3}
 passenv = NUMBER_OF_PROCESSORS
 deps =
      pytest
@@ -33,5 +34,5 @@ commands =
      ;  bash ./continuous_integration/build_test_ext.sh
      python -c "import struct; print('platform: %d' % (8 * struct.calcsize('P')))"
      python continuous_integration/install_coverage_subprocess_pth.py
-     py.test {posargs:-lv --maxfail=2 --timeout=10}
+     py.test {posargs:-lv --maxfail=2 --timeout=60}
      coverage combine --append


### PR DESCRIPTION
This should fix #160 reported by @rth for scikit-learn 0.20.

I decided to skip tests for the Spawn-based and ForkServer-based process pool executors under PyPy as they are not stable apparently. They are not used in joblib / scikit-learn though.

Let's see if the CI likes it.