### PR TITLE
ENH wrapper for non picklable objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,10 @@
 - Improve workers crash reporting by displaying the exitcodes of
   workers in `TerminatedWorkerError` (#173)
 
+- Add a `wrap_non_picklable_objects` decorator in `loky` to make it
+  easy to fix serialization failure for nested functions defined in
+  the `__main__` module. (#171)
+
 ### 2.3.1 - 2018-09-13 - Bug fix release
 
 - Improve error reporting when a worker process is terminated abruptly

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -13,10 +13,11 @@ To share function definition across multiple python processes, it is necessary t
 
 To avoid this limitation, :mod:`loky` relies on |cloudpickle| when it is present. |cloudpickle| is a fork of the pickle protocol which allows the serialization of a greater number of objects and it can be installed using :code:`pip install cloudpickle`. As this library is slower than the :mod:`pickle` module in the standard library, by default, :mod:`loky` uses it only to serialize objects which are detected to be in the :code:`__main__` module.
 
-There is two way to temper with the serialization in :mod:`loky`:
+There is three ways to temper with the serialization in :mod:`loky`:
 
 - Using the arguments :code:`job_reducers` and :code:`result_reducers`, it is possible to register custom reducers for the serialization process.
 - Setting the variable :code:`LOKY_PICKLER` to an available and valid serialization module. This module must present a valid :code:`Pickler` object. Setting the environment variable :code:`LOKY_PICKER=cloudpickle` will force :mod:`loky` to serialize everything with |cloudpickle| instead of just serializing the object detected to be in the :code:`__main__` module.
+- Using the decorator :func:`loky.wrap_unpicklable_objects` on the objects and functions which cannot be pickled by the regular protocol.
 
 
 Processes start methods in :mod:`loky`

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -17,7 +17,7 @@ There is three ways to temper with the serialization in :mod:`loky`:
 
 - Using the arguments :code:`job_reducers` and :code:`result_reducers`, it is possible to register custom reducers for the serialization process.
 - Setting the variable :code:`LOKY_PICKLER` to an available and valid serialization module. This module must present a valid :code:`Pickler` object. Setting the environment variable :code:`LOKY_PICKER=cloudpickle` will force :mod:`loky` to serialize everything with |cloudpickle| instead of just serializing the object detected to be in the :code:`__main__` module.
-- Using the decorator :func:`loky.wrap_unpicklable_objects` on the objects and functions which cannot be pickled by the regular protocol.
+- Using the decorator :func:`loky.wrap_unpicklable_objects` on the objects and functions which cannot be pickled by the regular protocol. This decorator forces the use of |cloudpickle| for the decorated object. Note that this sometimes include a performance overhead.
 
 
 Processes start methods in :mod:`loky`

--- a/docs/API.rst
+++ b/docs/API.rst
@@ -17,23 +17,19 @@ There are three ways to temper with the serialization in :mod:`loky`:
 
 - Using the arguments :code:`job_reducers` and :code:`result_reducers`, it is possible to register custom reducers for the serialization process.
 - Setting the variable :code:`LOKY_PICKLER` to an available and valid serialization module. This module must present a valid :code:`Pickler` object. Setting the environment variable :code:`LOKY_PICKER=cloudpickle` will force :mod:`loky` to serialize everything with |cloudpickle| instead of just serializing the object detected to be in the :code:`__main__` module.
-- Finally, it is possible to get an object-level control of the serialization protocol. Take this specific use case: a function call is done via :code:`ProcessPoolExecutor.submit`, with two arguments defined in the :code:`__main__`:
+- Finally, it is possible to wrap an unpicklable object using the :code:`loky.wrap_non_picklable_objects` decorator. In this case, all other objects are serialized as in the default behavior and the wrapped object is pickled through |cloudpickle|.
 
-    + one of them is a non-picklable object.
-    + another is a picklable object on which |cloudpickle| is known to perform significantly slower than pickle, for instance a large list or a large and dict.
+The benefits and drawbacks of each method are highlighted in this example_.
 
-  By default, the two arguments would be serialized using |cloudpickle|. However, the pickling performance can be improved by imposing :code:`LOKY_PICKER=pickle`, and wrapping the first argument using using :code:`loky.wrap_non_picklable_objects`. In this case, all objects that can be pickled are going through the faster :mod:`pickle`, and there is no more unnecessary overhead during serialization.
+
+.. autofunction:: loky.wrap_non_picklable_objects
+
 
 Processes start methods in :mod:`loky`
--------------------------------------
+--------------------------------------
 
 The API in :mod:`loky` provides a :func:`set_start_method` function to set the default  :code:`start_method`, which controls the way :class:`Process` are started. The available methods are {:code:`'loky'`, :code:`'loky_int_main'`, :code:`'spawn'`}. On unix, the start methods {:code:`'fork'`, :code:`'forkserver'`} are also available.
 Note that :mod:`loky` isnot compatible with :func:`multiprocessing.set_start_method` function. The default start method needs to be set with the provided function to ensure a proper behavior.
-
-
-.. |cloudpickle| raw:: html
-
-    <a href="https://github.com/cloudpipe/cloudpickle"><code>cloudpickle</code></a>
 
 
 Protection against memory leaks
@@ -61,3 +57,11 @@ not happening.
 
 .. [#periodically_fn] every 1 second. This constant is define in :code:`loky.process_executor._MEMORY_LEAK_CHECK_DELAY`
 .. [#psutil_unusual_fn] an increase of 100MB compared to a reference, which is defined as the residual memory usage of the worker after it completed its first task
+
+
+
+.. |cloudpickle| raw:: html
+
+    <a href="https://github.com/cloudpipe/cloudpickle"><code>cloudpickle</code></a>
+
+.. _example :  auto_examples/cloudpickle_wrapper.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,6 +194,8 @@ sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     # path where to save gallery generated examples
     'gallery_dirs': 'auto_examples',
+    'filename_pattern': '',
+    'ignore_pattern': 'deadlock_',
     'reference_url': {
         'loky': None
     },

--- a/examples/cloudpickle_wrapper.py
+++ b/examples/cloudpickle_wrapper.py
@@ -15,7 +15,6 @@ import sys
 import time
 import traceback
 from loky import set_loky_pickler
-from loky import BrokenProcessPool
 from loky import get_reusable_executor
 from loky import wrap_non_picklable_objects
 

--- a/examples/cloudpickle_wrapper.py
+++ b/examples/cloudpickle_wrapper.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""
+Serialization of un-picklable objects
+=====================================
+
+This example highlights the options for tempering with loky serialization
+process.
+
+"""
+
+# Code source: Thomas Moreau
+# License: BSD 3 clause
+
+import sys
+import time
+import traceback
+from loky import set_loky_pickler
+from loky import BrokenProcessPool
+from loky import get_reusable_executor
+from loky import wrap_non_picklable_objects
+
+###############################################################################
+# First, define functions which cannot be pickled with the standard ``pickle``
+# protocol. They cannot be serialized with ``pickle`` because they leave in the
+# `` __main__`` module. They can however be serialized with ``cloudpickle``.
+#
+
+
+def call_function(list_or_func, x, *args):
+    while isinstance(list_or_func, list):
+        list_or_func = list_or_func[0]
+    return list_or_func(x)
+
+
+def func_async(i):
+    return 2 * i
+
+
+###############################################################################
+# With the default behavior, ``loky`` is able to detect that this function is
+# in the ``__main__`` module and internally use a wrapper with ``cloudpickle``
+# to serialize it.
+#
+
+executor = get_reusable_executor(max_workers=1)
+print(executor.submit(call_function, func_async, 21).result())
+
+###############################################################################
+# However, the mechanism to detect that the wrapper is needed can be costly in
+# the case where this function is nested in objects that are picklable. For
+# instance, if this function is given in a list of list, loky won't be able
+# to wrap it and the de-serialization of the task will fail.
+#
+
+try:
+    executor = get_reusable_executor(max_workers=1)
+    executor.submit(id, [[func_async]]).result()
+except Exception:
+    traceback.print_exc(file=sys.stdout)
+
+
+###############################################################################
+# To avoid this, it is possible to fully rely on ``cloudpickle`` to serialize
+# all communication between the main process and the workers. This can be done
+# with an environment variable ``LOKY_PICKLER=cloudpickle`` set before the
+# script is launched, or with the switch ``set_loky_pickler`` provided in the
+# ``loky`` API.
+#
+
+set_loky_pickler('cloudpickle')
+executor = get_reusable_executor(max_workers=1)
+print(executor.submit(call_function, [[func_async]], 21).result())
+
+
+###############################################################################
+# For most use-case, this solution is sufficient. However, ``cloudpickle``
+# can be slow to serialize large python objects, such as dict or list.
+#
+
+# We are still using ``cloudpickle`` to serialize the task as we did not reset
+# the loky_pickler.
+large_list = list(range(1000000))
+t_start = time.time()
+executor = get_reusable_executor(max_workers=1)
+executor.submit(call_function, [[func_async]], 21, large_list).result()
+print("With cloudpickle serialization: {:.3f}s".format(time.time() - t_start))
+
+# Now reset the `loky_pickler` to the default behavior, with a picklable
+# function ``id``.
+set_loky_pickler()
+t_start = time.time()
+executor = get_reusable_executor(max_workers=1)
+executor.submit(call_function, [[id]], 21, large_list).result()
+print("With default serialization: {:.3f}s".format(time.time() - t_start))
+
+
+###############################################################################
+# To temper this, it is possible to wrap the non-picklable function using
+# :func:`wrap_non_picklable_objects`. This changes the serialization behavior
+# only for this function and keep the default behavior for all objects. The
+# drawback of this solution is that it modifies the object and it can have side
+# effects.
+#
+
+@wrap_non_picklable_objects
+def func_async(i):
+    return 2 * i
+
+
+t_start = time.time()
+executor = get_reusable_executor(max_workers=1)
+executor.submit(call_function, [[func_async]], 21, large_list).result()
+print("With default and wrapper n: {:.3f}s".format(time.time() - t_start))
+
+###############################################################################
+# The same wrapper can also be used for non-picklable classes. Other use cases
+# for this wrapper include ``dict`` with non-serializable objects or other
+# serializable objects containing a field with non-serializable objects. Note
+# that the side effects of :func:`wrap_non_picklable_objects` can be worst as
+# it can breaks the magic methods such as ``_add__`` and can mess up the
+# ``isinstance`` and ``issubclass`` functions.
+#

--- a/examples/cloudpickle_wrapper.py
+++ b/examples/cloudpickle_wrapper.py
@@ -20,8 +20,9 @@ from loky import wrap_non_picklable_objects
 
 ###############################################################################
 # First, define functions which cannot be pickled with the standard ``pickle``
-# protocol. They cannot be serialized with ``pickle`` because they leave in the
-# `` __main__`` module. They can however be serialized with ``cloudpickle``.
+# protocol. They cannot be serialized with ``pickle`` because they are defined
+# in the ``__main__`` module. They can however be serialized with
+# ``cloudpickle``.
 #
 
 
@@ -45,10 +46,10 @@ executor = get_reusable_executor(max_workers=1)
 print(executor.submit(call_function, func_async, 21).result())
 
 ###############################################################################
-# However, the mechanism to detect that the wrapper is needed can be costly in
-# the case where this function is nested in objects that are picklable. For
-# instance, if this function is given in a list of list, loky won't be able
-# to wrap it and the de-serialization of the task will fail.
+# However, the mechanism to detect that the wrapper is needed fails when this
+# function is nested in objects that are picklable. For instance, if this
+# function is given in a list of list, loky won't be able to wrap it and the
+# serialization of the task will fail.
 #
 
 try:
@@ -60,7 +61,7 @@ except Exception:
 
 ###############################################################################
 # To avoid this, it is possible to fully rely on ``cloudpickle`` to serialize
-# all communication between the main process and the workers. This can be done
+# all communications between the main process and the workers. This can be done
 # with an environment variable ``LOKY_PICKLER=cloudpickle`` set before the
 # script is launched, or with the switch ``set_loky_pickler`` provided in the
 # ``loky`` API.
@@ -72,7 +73,7 @@ print(executor.submit(call_function, [[func_async]], 21).result())
 
 
 ###############################################################################
-# For most use-case, this solution is sufficient. However, ``cloudpickle``
+# For most use-cases, this solution is sufficient. However, ``cloudpickle``
 # can be slow to serialize large python objects, such as dict or list.
 #
 
@@ -96,7 +97,7 @@ print("With default serialization: {:.3f}s".format(time.time() - t_start))
 ###############################################################################
 # To temper this, it is possible to wrap the non-picklable function using
 # :func:`wrap_non_picklable_objects`. This changes the serialization behavior
-# only for this function and keep the default behavior for all objects. The
+# only for this function and keeps the default behavior for all objects. The
 # drawback of this solution is that it modifies the object and it can have side
 # effects.
 #
@@ -116,6 +117,6 @@ print("With default and wrapper n: {:.3f}s".format(time.time() - t_start))
 # for this wrapper include ``dict`` with non-serializable objects or other
 # serializable objects containing a field with non-serializable objects. Note
 # that the side effects of :func:`wrap_non_picklable_objects` can be worst as
-# it can breaks the magic methods such as ``_add__`` and can mess up the
+# it can breaks the magic methods such as ``__add__`` and can mess up the
 # ``isinstance`` and ``issubclass`` functions.
 #

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -10,13 +10,15 @@ from ._base import ALL_COMPLETED, FIRST_COMPLETED, FIRST_EXCEPTION
 
 from .backend.context import cpu_count
 from .reusable_executor import get_reusable_executor
+from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
 
 
 __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "Future", "Executor", "ProcessPoolExecutor",
            "BrokenProcessPool", "CancelledError", "TimeoutError",
-           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED", ]
+           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
+           "wrap_non_picklable_objects"]
 
 
 __version__ = '2.3.2dev0'

--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -9,6 +9,7 @@ from ._base import TimeoutError, CancelledError
 from ._base import ALL_COMPLETED, FIRST_COMPLETED, FIRST_EXCEPTION
 
 from .backend.context import cpu_count
+from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
 from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
@@ -18,7 +19,7 @@ __all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
            "Future", "Executor", "ProcessPoolExecutor",
            "BrokenProcessPool", "CancelledError", "TimeoutError",
            "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
-           "wrap_non_picklable_objects"]
+           "wrap_non_picklable_objects", "set_loky_pickler"]
 
 
 __version__ = '2.3.2dev0'

--- a/loky/backend/__init__.py
+++ b/loky/backend/__init__.py
@@ -3,8 +3,6 @@ import sys
 
 from .context import get_context
 
-LOKY_PICKLER = os.environ.get("LOKY_PICKLER")
-
 if sys.version_info > (3, 4):
 
     def _make_name():

--- a/loky/backend/queues.py
+++ b/loky/backend/queues.py
@@ -22,7 +22,7 @@ from multiprocessing.queues import Full
 from multiprocessing.queues import _sentinel, Queue as mp_Queue
 from multiprocessing.queues import SimpleQueue as mp_SimpleQueue
 
-from .reduction import CustomizableLokyPickler
+from .reduction import loads, dumps
 from .context import assert_spawning, get_context
 
 
@@ -147,8 +147,7 @@ class Queue(mp_Queue):
                             return
 
                         # serialize the data before acquiring the lock
-                        obj_ = CustomizableLokyPickler.dumps(
-                            obj, reducers=reducers)
+                        obj_ = dumps(obj, reducers=reducers)
                         if wacquire is None:
                             send_bytes(obj_)
                         else:
@@ -227,12 +226,12 @@ class SimpleQueue(mp_SimpleQueue):
             with self._rlock:
                 res = self._reader.recv_bytes()
             # unserialize the data after having released the lock
-            return CustomizableLokyPickler.loads(res)
+            return loads(res)
 
     # Overload put to use our customizable reducer
     def put(self, obj):
         # serialize the data before acquiring the lock
-        obj = CustomizableLokyPickler.dumps(obj, reducers=self._reducers)
+        obj = dumps(obj, reducers=self._reducers)
         if self._wlock is None:
             # writes to a message oriented win32 pipe are atomic
             self._writer.send_bytes(obj)

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -63,7 +63,7 @@ class _ReducerRegistry(object):
             def dispatcher(cls, obj):
                 reduced = reduce_func(obj)
                 cls.save_reduce(obj=obj, *reduced)
-            cls.dispatch[type] = dispatcher
+            cls.dispatch_table[type] = dispatcher
         else:
             cls.dispatch_table[type] = reduce_func
 

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -163,22 +163,22 @@ def set_loky_pickler(pickler=None):
         if sys.version_info < (3,):
             # Make the dispatch registry an instance level attribute instead of
             # a reference to the class dictionary under Python 2
-            dispatch = pickler_cls.dispatch.copy()
-            dispatch.update(_ReducerRegistry.dispatch_table)
+            _dispatch = pickler_cls.dispatch.copy()
+            _dispatch.update(_ReducerRegistry.dispatch_table)
         else:
             # Under Python 3 initialize the dispatch table with a copy of the
             # default registry
-            dispatch_table = copyreg.dispatch_table.copy()
-            dispatch_table.update(_ReducerRegistry.dispatch_table)
+            _dispatch_table = copyreg.dispatch_table.copy()
+            _dispatch_table.update(_ReducerRegistry.dispatch_table)
 
         def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
             pickler_cls.__init__(self, writer, protocol=protocol)
             if reducers is None:
                 reducers = {}
             if sys.version_info < (3,):
-                self.dispatch = self.dispatch.copy()
+                self.dispatch = self._dispatch.copy()
             else:
-                self.dispatch_table = self.dispatch_table.copy()
+                self.dispatch_table = self._dispatch_table.copy()
             for type, reduce_func in reducers.items():
                 self.register(type, reduce_func)
 

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -216,15 +216,7 @@ def loads(buf):
 def dump(obj, file, reducers=None, protocol=None):
     '''Replacement for pickle.dump() using _LokyPickler.'''
     global _LokyPickler
-    pickler = _LokyPickler(file, reducers=reducers, protocol=protocol)
-
-    from pickle import Pickler
-    assert issubclass(_LokyPickler, Pickler)
-    if reducers is None:
-        reducers = {}
-    for type, reduce_func in reducers.items():
-        pickler.dispatch_table[type] = reduce_func
-    pickler.dump(obj)
+    _LokyPickler(file, reducers=reducers, protocol=protocol).dump(obj)
 
 
 def dumps(obj, reducers=None, protocol=None):

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -15,10 +15,13 @@ import warnings
 from multiprocessing import util
 try:
     # Python 2 compat
-    from cPickle import loads
+    from cPickle import loads as pickle_loads
 except ImportError:
-    from pickle import loads
+    from pickle import loads as pickle_loads
     import copyreg
+
+from pickle import HIGHEST_PROTOCOL
+from . import LOKY_PICKLER
 
 if sys.platform == "win32":
     if sys.version_info[:2] > (3, 3):
@@ -26,48 +29,16 @@ if sys.platform == "win32":
     else:
         from multiprocessing.forking import duplicate
 
-from pickle import HIGHEST_PROTOCOL
-from . import LOKY_PICKLER
-
-Pickler = None
-try:
-    if LOKY_PICKLER is None or LOKY_PICKLER == "":
-        from pickle import Pickler
-    elif LOKY_PICKLER == "cloudpickle":
-        from cloudpickle import CloudPickler as Pickler
-    elif LOKY_PICKLER == "dill":
-        from dill import Pickler
-    elif LOKY_PICKLER != "pickle":
-        from importlib import import_module
-        mpickle = import_module(LOKY_PICKLER)
-        Pickler = mpickle.Pickler
-    util.debug("Using default backend {} for pickling."
-               .format(LOKY_PICKLER if LOKY_PICKLER is not None
-                       else "pickle"))
-except ImportError:
-    warnings.warn("Failed to import {} as asked in LOKY_PICKLER. Make sure"
-                  " it is correctly installed on your system. Falling back"
-                  " to default builtin pickle.".format(LOKY_PICKLER))
-except AttributeError:  # pragma: no cover
-    warnings.warn("Failed to find Pickler object in module {}. The module "
-                  "specified in LOKY_PICKLER should implement a Pickler "
-                  "object. Falling back to default builtin pickle."
-                  .format(LOKY_PICKLER))
-
-
-if Pickler is None:
-    from pickle import Pickler
-
 
 ###############################################################################
 # Enable custom pickling in Loky.
 # To allow instance customization of the pickling process, we use 2 classes.
-# _LokyPickler gives module level customization and CustomizablePickler permits
-# to use instance base custom reducers.  Only CustomizablePickler should be
-# used.
+# _ReducerRegistry gives module level customization and CustomizablePickler
+# permits to use instance base custom reducers. Only CustomizablePickler
+# should be used.
 
-class _LokyPickler(Pickler):
-    """Pickler that uses custom reducers.
+class _ReducerRegistry(object):
+    """Registry for custom reducers.
 
     HIGHEST_PROTOCOL is selected by default as this pickler is used
     to pickle ephemeral datastructures for interprocess communication
@@ -81,19 +52,12 @@ class _LokyPickler(Pickler):
     # feature from http://bugs.python.org/issue14166 that makes it possible
     # to use the C implementation of the Pickler which is faster.
 
-    if hasattr(Pickler, 'dispatch'):
-        # Make the dispatch registry an instance level attribute instead of
-        # a reference to the class dictionary under Python 2
-        dispatch = Pickler.dispatch.copy()
-    else:
-        # Under Python 3 initialize the dispatch table with a copy of the
-        # default registry
-        dispatch_table = copyreg.dispatch_table.copy()
+    dispatch_table = {}
 
     @classmethod
     def register(cls, type, reduce_func):
         """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
+        if sys.version_info < (3,):
             # Python 2 pickler dispatching is not explicitly customizable.
             # Let us use a closure to workaround this limitation.
             def dispatcher(cls, obj):
@@ -104,60 +68,10 @@ class _LokyPickler(Pickler):
             cls.dispatch_table[type] = reduce_func
 
 
-class CustomizableLokyPickler(Pickler):
-    def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
-        Pickler.__init__(self, writer, protocol=protocol)
-        if reducers is None:
-            reducers = {}
-        if hasattr(Pickler, 'dispatch'):
-            # Make the dispatch registry an instance level attribute instead of
-            # a reference to the class dictionary under Python 2
-            self.dispatch = _LokyPickler.dispatch.copy()
-        else:
-            # Under Python 3 initialize the dispatch table with a copy of the
-            # default registry
-            self.dispatch_table = _LokyPickler.dispatch_table.copy()
-        for type, reduce_func in reducers.items():
-            self.register(type, reduce_func)
-
-    def register(self, type, reduce_func):
-        """Attach a reducer function to a given type in the dispatch table."""
-        if hasattr(Pickler, 'dispatch'):
-            # Python 2 pickler dispatching is not explicitly customizable.
-            # Let us use a closure to workaround this limitation.
-            def dispatcher(self, obj):
-                reduced = reduce_func(obj)
-                self.save_reduce(obj=obj, *reduced)
-            self.dispatch[type] = dispatcher
-        else:
-            self.dispatch_table[type] = reduce_func
-
-    @classmethod
-    def loads(self, buf):
-        if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
-            buf = buf.getvalue()
-        return loads(buf)
-
-    @classmethod
-    def dumps(cls, obj, reducers=None, protocol=None):
-        buf = io.BytesIO()
-        p = cls(buf, reducers=reducers, protocol=protocol)
-        p.dump(obj)
-        if sys.version_info < (3, 3):
-            return buf.getvalue()
-        return buf.getbuffer()
-
-
-def dump(obj, file, reducers=None, protocol=None):
-    '''Replacement for pickle.dump() using LokyPickler.'''
-    CustomizableLokyPickler(file, reducers=reducers,
-                            protocol=protocol).dump(obj)
-
-
 ###############################################################################
 # Registers extra pickling routines to improve picklization  for loky
 
-register = _LokyPickler.register
+register = _ReducerRegistry.register
 
 
 # make methods picklable
@@ -205,3 +119,126 @@ if sys.platform != "win32":
     from ._posix_reduction import _mk_inheritable  # noqa: F401
 else:
     from . import _win_reduction  # noqa: F401
+
+# global variable to change the pickler behavior
+_LokyPickler = None
+_use_cloudpickle_wrapper = True
+
+
+def set_loky_pickler(pickler=None):
+    global _LokyPickler, _use_cloudpickle_wrapper
+
+    if pickler is None:
+        pickler = LOKY_PICKLER
+
+    pickler_cls = None
+
+    if pickler in ["pickle", "", None]:
+        # Only use the cloudpickle_wrapper when pickler is None or ''
+        from pickle import Pickler as pickler_cls
+        _use_cloudpickle_wrapper = pickler != "pickle"
+    else:
+        _use_cloudpickle_wrapper = False
+        try:
+            if pickler == 'cloudpickle':
+                from cloudpickle import CloudPickler as pickler_cls
+            else:
+                from importlib import import_module
+                module_pickle = import_module(pickler)
+                if not hasattr(module_pickle, 'Pickler'):
+                    raise ValueError("Failed to find Pickler object in module "
+                                     "'{}', requested for pickling."
+                                     .format(pickler))
+                pickler_cls = module_pickle.Pickler
+        except ImportError:
+            raise ValueError("Failed to import '{}' requested for pickler. "
+                             "Make sure it is available on your system."
+                             .format(pickler))
+
+    util.debug("Using default backend {} for pickling."
+               .format(pickler if pickler else "pickle"))
+
+    class CustomizablePickler(pickler_cls):
+
+        if sys.version_info < (3,):
+            # Make the dispatch registry an instance level attribute instead of
+            # a reference to the class dictionary under Python 2
+            dispatch = pickler_cls.dispatch.copy()
+            dispatch.update(_ReducerRegistry.dispatch_table)
+        else:
+            # Under Python 3 initialize the dispatch table with a copy of the
+            # default registry
+            dispatch_table = copyreg.dispatch_table.copy()
+            dispatch_table.update(_ReducerRegistry.dispatch_table)
+
+        def __init__(self, writer, reducers=None, protocol=HIGHEST_PROTOCOL):
+            pickler_cls.__init__(self, writer, protocol=protocol)
+            if reducers is None:
+                reducers = {}
+            if sys.version_info < (3,):
+                self.dispatch = self.dispatch.copy()
+            else:
+                self.dispatch_table = self.dispatch_table.copy()
+            for type, reduce_func in reducers.items():
+                self.register(type, reduce_func)
+
+        def register(self, type, reduce_func):
+            """Attach a reducer function to a given type in the dispatch table."""
+            util.debug((type, "register", reduce_func))
+            if sys.version_info < (3,):
+                # Python 2 pickler dispatching is not explicitly customizable.
+                # Let us use a closure to workaround this limitation.
+                    def dispatcher(self, obj):
+                        reduced = reduce_func(obj)
+                        self.save_reduce(obj=obj, *reduced)
+                    self.dispatch[type] = dispatcher
+            else:
+                self.dispatch_table[type] = reduce_func
+
+    _LokyPickler = CustomizablePickler
+
+
+def use_cloudpickle_wrapper():
+    return _use_cloudpickle_wrapper
+
+
+# Set it to its default value
+set_loky_pickler()
+
+
+def loads(buf):
+    # Compat for python2.7 version
+    if sys.version_info < (3, 3) and isinstance(buf, io.BytesIO):
+        buf = buf.getvalue()
+    return pickle_loads(buf)
+
+
+def dump(obj, file, reducers=None, protocol=None):
+    '''Replacement for pickle.dump() using _LokyPickler.'''
+    global _LokyPickler
+    pickler = _LokyPickler(file, reducers=reducers, protocol=protocol)
+
+    from pickle import Pickler
+    assert issubclass(_LokyPickler, Pickler)
+    if reducers is None:
+        reducers = {}
+    for type, reduce_func in reducers.items():
+        pickler.dispatch_table[type] = reduce_func
+    pickler.dump(obj)
+
+
+def dumps(obj, reducers=None, protocol=None):
+    global _LokyPickler
+
+    buf = io.BytesIO()
+    dump(obj, buf, reducers=reducers, protocol=protocol)
+    if sys.version_info < (3, 3):
+        return buf.getvalue()
+    return buf.getbuffer()
+
+
+__all__ = ["dump", "dumps", "loads", "register",
+           "set_loky_pickler", "use_cloudpickle_wrapper"]
+
+if sys.platform == "win32":
+    __all__ += ["duplicate"]

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -28,7 +28,7 @@ class CloudpickledObjectWrapper(object):
     def __getattr__(self, attr):
         # Ensure that the wrapped object can be used seemlessly as the
         # previous object.
-        if attr not in ['__reduce__', '_obj', '_keep_wrapper']:
+        if attr not in ['_obj', '_keep_wrapper']:
             return getattr(self._obj, attr)
         return getattr(self, attr)
 
@@ -105,6 +105,7 @@ def wrap_non_picklable_objects(obj):
                 self._obj = obj(*args, **kwargs)
                 self._keep_wrapper = True
 
+        CloudpickledClassWrapper.__name__ = obj.__name__
         return CloudpickledClassWrapper
 
     # If obj is an instance of a class, just wrap it in a regular

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -26,6 +26,10 @@ class CloudpickledObjectWrapper(object):
         return _reconstruct_wrapper, (_pickled_object, self._keep_wrapper)
 
     def __call__(self, *args, **kwargs):
+        # Do not make a callable wrapper when the wrapped object is not.
+        if not callable(self._obj):
+            raise TypeError("'{}' object is not callable"
+                            .format(self._obj.__class__))
         return self._obj(*args, **kwargs)
 
     def __getattr__(self, attr):

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -23,11 +23,7 @@ class CloudpickledObjectWrapper(object):
         if not self._keep_wrapper:
             return loads, (_pickled_object,)
 
-        return self._reconstruct_wrapper, (_pickled_object, self._keep_wrapper)
-
-    @staticmethod
-    def _reconstruct_wrapper(_pickled_object, keep_wrapper):
-        return CloudpickledObjectWrapper(loads(_pickled_object), keep_wrapper)
+        return _reconstruct_wrapper, (_pickled_object, self._keep_wrapper)
 
     def __call__(self, *args, **kwargs):
         return self._obj(*args, **kwargs)
@@ -38,6 +34,10 @@ class CloudpickledObjectWrapper(object):
         if attr not in ['__reduce__', '_obj', '_keep_wrapper']:
             return getattr(self._obj, attr)
         return getattr(self, attr)
+
+
+def _reconstruct_wrapper(_pickled_object, keep_wrapper):
+    return CloudpickledObjectWrapper(loads(_pickled_object), keep_wrapper)
 
 
 def _wrap_objects_when_needed(obj):
@@ -90,9 +90,9 @@ def wrap_non_picklable_objects(obj):
     # the object internally and wrap it directly in a CloudpickledObjectWrapper
     if isinstance(obj, type):
         class CloudpickledClassWrapper(CloudpickledObjectWrapper):
-            def __init__(self, *args, _keep_wrapper=True, **kwargs):
+            def __init__(self, *args, **kwargs):
                 self._obj = obj(*args, **kwargs)
-                self._keep_wrapper = _keep_wrapper
+                self._keep_wrapper = True
 
         return CloudpickledClassWrapper
 

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -88,7 +88,7 @@ def wrap_non_picklable_objects(obj):
 
     # If obj is an  class, create a CloudpickledClassWrappers which instantiate
     # the object internally and wrap it directly in a CloudpickledObjectWrapper
-    if isinstance(obj, type):
+    if inspect.isclass(obj):
         class CloudpickledClassWrapper(CloudpickledObjectWrapper):
             def __init__(self, *args, **kwargs):
                 self._obj = obj(*args, **kwargs)

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -1,7 +1,7 @@
 import inspect
 from functools import partial
 
-from .backend import LOKY_PICKLER
+from .backend.reduction import use_cloudpickle_wrapper
 
 try:
     from cloudpickle import dumps, loads
@@ -52,7 +52,7 @@ def _reconstruct_wrapper(_pickled_object, keep_wrapper):
 
 
 def _wrap_objects_when_needed(obj):
-    if LOKY_PICKLER or not cloudpickle:
+    if not use_cloudpickle_wrapper() or not cloudpickle:
         return obj
 
     need_wrap = "__main__" in getattr(obj, "__module__", "")

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -86,9 +86,9 @@ def _wrap_objects_when_needed(obj):
 def wrap_non_picklable_objects(obj):
     """Wrapper for non-picklable object to use cloudpickle to serialize them.
 
-    Note that this wrapper tends to slow down the serialization process has it
+    Note that this wrapper tends to slow down the serialization process as it
     is done with cloudpickle which is typically slower compared to pickle. The
-    proper way to solve serialization issue is to avoid defining functions and
+    proper way to solve serialization issues is to avoid defining functions and
     objects in the main scripts and to implement __reduce__ functions for
     complex classes.
     """

--- a/loky/cloudpickle_wrapper.py
+++ b/loky/cloudpickle_wrapper.py
@@ -97,7 +97,7 @@ def wrap_non_picklable_objects(obj):
                           "cloudpickle to allow extended serialization. "
                           "(`pip install cloudpickle`).")
 
-    # If obj is an  class, create a CloudpickledClassWrappers which instantiate
+    # If obj is a  class, create a CloudpickledClassWrapper which instantiates
     # the object internally and wrap it directly in a CloudpickledObjectWrapper
     if inspect.isclass(obj):
         class CloudpickledClassWrapper(CloudpickledObjectWrapper):

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -80,7 +80,7 @@ from .backend.compat import wait
 from .backend.compat import set_cause
 from .backend.context import cpu_count
 from .backend.queues import Queue, SimpleQueue, Full
-from .cloudpickle_wrapper import _wrap_non_picklable_objects
+from .cloudpickle_wrapper import _wrap_objects_when_needed
 from .backend.utils import recursive_terminate, get_exitcodes_terminated_worker
 
 try:
@@ -271,9 +271,9 @@ class _CallItem(object):
     def __getstate__(self):
         return (
             self.work_id,
-            _wrap_non_picklable_objects(self.fn),
-            [_wrap_non_picklable_objects(a) for a in self.args],
-            {k: _wrap_non_picklable_objects(a) for k, a in self.kwargs.items()}
+            _wrap_objects_when_needed(self.fn),
+            [_wrap_objects_when_needed(a) for a in self.args],
+            {k: _wrap_objects_when_needed(a) for k, a in self.kwargs.items()}
         )
 
     def __setstate__(self, state):
@@ -894,8 +894,8 @@ class ProcessPoolExecutor(_base.Executor):
 
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
-        self._initializer = _wrap_non_picklable_objects(initializer)
-        self._initargs = [_wrap_non_picklable_objects(a) for a in initargs]
+        self._initializer = _wrap_objects_when_needed(initializer)
+        self._initargs = [_wrap_objects_when_needed(a) for a in initargs]
 
         _check_max_depth(self._context)
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -829,13 +829,6 @@ class BrokenProcessPool(_BPPException):
     process or when unpickling the result value in the parent process. It can
     also be caused by a worker process being terminated unexpectedly.
     """
-    if sys.version_info < (3, ):
-        def __str__(self):
-            msg = repr(self)
-            if getattr(self, "__cause__", None) is not None:
-                msg += "\n\nThis was caused directly by "
-                msg += str(self.__cause__)
-            return msg
 
 
 class TerminatedWorkerError(BrokenProcessPool):

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -829,6 +829,13 @@ class BrokenProcessPool(_BPPException):
     process or when unpickling the result value in the parent process. It can
     also be caused by a worker process being terminated unexpectedly.
     """
+    if sys.version_info < (3, ):
+        def __str__(self):
+            msg = repr(self)
+            if getattr(self, "__cause__", None) is not None:
+                msg += "\n\nThis was caused directly by "
+                msg += str(self.__cause__)
+            return msg
 
 
 class TerminatedWorkerError(BrokenProcessPool):

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -313,11 +313,11 @@ class _SafeQueue(Queue):
                 del work_item
             self.thread_wakeup.wakeup()
         else:
-            super()._on_queue_feeder_error(e, obj)
+            super(_SafeQueue, self)._on_queue_feeder_error(e, obj)
 
 
 def _get_chunks(chunksize, *iterables):
-    """ Iterates over zip()ed iterables in chunks. """
+    """Iterates over zip()ed iterables in chunks. """
     if sys.version_info < (3, 3):
         it = itertools.izip(*iterables)
     else:
@@ -330,7 +330,7 @@ def _get_chunks(chunksize, *iterables):
 
 
 def _process_chunk(fn, chunk):
-    """ Processes a chunk of an iterable passed to map.
+    """Processes a chunk of an iterable passed to map.
 
     Runs the function passed to map() on a chunk of the
     iterable passed to map.

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -749,14 +749,15 @@ class ExecutorTest:
             max_workers=2, context=self.context, job_reducers=job_reducers,
             result_reducers=result_reducers
         )
-        # self.executor = self.executor_type(max_workers=2, context=self.context)
+        self.executor = self.executor_type(max_workers=2, context=self.context)
 
         obj = MyObject(1)
         try:
-            # ret_obj = self.executor.submit(self.return_inputs, obj).result()[0]
-            ret_obj_custom = executor.submit(self.return_inputs, obj).result()[0]
+            ret_obj_custom = executor.submit(
+                    self.return_inputs, obj).result()[0]
+            ret_obj = self.executor.submit(self.return_inputs, obj).result()[0]
 
-            # assert ret_obj.value == 1
+            assert ret_obj.value == 1
             assert ret_obj_custom.value == 42
         finally:
             executor.shutdown(wait=True)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -91,6 +91,9 @@ class MyObject(object):
     def __init__(self, value=0):
         self.value = value
 
+    def __repr__(self):
+        return "MyObject({})".format(self.value)
+
     def my_method(self):
         pass
 
@@ -746,16 +749,17 @@ class ExecutorTest:
             max_workers=2, context=self.context, job_reducers=job_reducers,
             result_reducers=result_reducers
         )
-        self.executor = self.executor_type(max_workers=2, context=self.context)
+        # self.executor = self.executor_type(max_workers=2, context=self.context)
 
         obj = MyObject(1)
-        ret_obj = self.executor.submit(self.return_inputs, obj).result()[0]
-        ret_obj_custom = executor.submit(self.return_inputs, obj).result()[0]
+        try:
+            # ret_obj = self.executor.submit(self.return_inputs, obj).result()[0]
+            ret_obj_custom = executor.submit(self.return_inputs, obj).result()[0]
 
-        assert ret_obj.value == 1
-        assert ret_obj_custom.value == 42
-
-        executor.shutdown(wait=True)
+            # assert ret_obj.value == 1
+            assert ret_obj_custom.value == 42
+        finally:
+            executor.shutdown(wait=True)
 
     @classmethod
     def _test_max_depth(cls, max_depth=10, kill_workers=False, ctx=None):

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -108,8 +108,9 @@ class TestCloudpickleWrapper:
             assert test_func(test_obj.return_func)() == 42
 
             # Make sure the wrapper do not make the object callable
-            # with pytest.raises(TypeError, match="Test'"):
-            #     test_obj()
+            with pytest.raises(TypeError,
+                              match="'Test' object is not callable"):
+                test_obj()
             
             assert not callable(test_obj)
 

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -84,6 +84,7 @@ class TestCloudpickleWrapper:
         # and thus test LokyProcess without the extra argument. For running
         # a script, it is necessary to use init_main_module=False.
         code = """if True:
+            import pytest
             from loky import get_reusable_executor
             from loky.cloudpickle_wrapper import wrap_non_picklable_objects
 
@@ -105,6 +106,10 @@ class TestCloudpickleWrapper:
             assert test_func(42) == 42
             assert test_obj.return_func() == 42
             assert test_func(test_obj.return_func)() == 42
+
+            # Make sure the wrapper do not make the object callable
+            with pytest.raises(TypeError, match="Test'"):
+                test_obj()
 
             # Make sure it is picklable even when the executor does not rely on
             # cloudpickle.

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -108,8 +108,10 @@ class TestCloudpickleWrapper:
             assert test_func(test_obj.return_func)() == 42
 
             # Make sure the wrapper do not make the object callable
-            with pytest.raises(TypeError, match="Test'"):
-                test_obj()
+            # with pytest.raises(TypeError, match="Test'"):
+            #     test_obj()
+            
+            assert not callable(test_obj)
 
             # Make sure it is picklable even when the executor does not rely on
             # cloudpickle.

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import pytest
+from tempfile import mkstemp
+
+
+from .utils import check_subprocess_call
+
+
+class TestCloudpickleWrapper:
+
+    def test_serialization_function_from_main(self):
+        # check that the init_main_module parameter works properly
+        # when using -c option, we don't need the safeguard if __name__ ..
+        # and thus test LokyProcess without the extra argument. For running
+        # a script, it is necessary to use init_main_module=False.
+        code = """if True:
+            from loky import get_reusable_executor
+
+            def test_func(x):
+                pass
+
+            e = get_reusable_executor()
+            e.submit(test_func, 42).result()
+            print("ok")
+        """
+        cmd = [sys.executable]
+        try:
+            fid, filename = mkstemp(suffix="_joblib.py")
+            os.close(fid)
+            with open(filename, mode='wb') as f:
+                f.write(code.encode('ascii'))
+            cmd += [filename]
+            check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10)
+
+            # Makes sure that if LOKY_PICKLER is set to default pickle, the
+            # tasks are not wrapped with cloudpickle and it is not possible
+            # using functions from the main module.
+            with pytest.raises(ValueError, match=r'A task has failed to un-s'):
+                check_subprocess_call(cmd, timeout=10,
+                                      env={'LOKY_PICKLER': 'pickle'})
+        finally:
+            os.unlink(filename)
+
+    def test_serialization_class_from_main(self):
+        # check that the init_main_module parameter works properly
+        # when using -c option, we don't need the safeguard if __name__ ..
+        # and thus test LokyProcess without the extra argument. For running
+        # a script, it is necessary to use init_main_module=False.
+        code = """if True:
+            from loky import get_reusable_executor
+
+            class Test:
+                def __init__(self, x=42):
+                    self.x = x
+
+                def test_func(self, x):
+                    return 42
+
+            def pass_all(*args, **kwargs):
+                pass
+
+            e = get_reusable_executor()
+            e.submit(pass_all, Test()).result()
+            e.submit(pass_all, x=Test()).result()
+            e.submit(pass_all, 1, 2, a=0, x=Test()).result()
+            assert e.submit(Test().test_func, 0).result() == 42
+            print("ok")
+        """
+        cmd = [sys.executable]
+        try:
+            fid, filename = mkstemp(suffix="_joblib.py")
+            os.close(fid)
+            with open(filename, mode='wb') as f:
+                f.write(code.encode('ascii'))
+            cmd += [filename]
+            check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10)
+        finally:
+            os.unlink(filename)
+
+    def test_cloudpickle_flag_wrapper(self):
+        # check that the init_main_module parameter works properly
+        # when using -c option, we don't need the safeguard if __name__ ..
+        # and thus test LokyProcess without the extra argument. For running
+        # a script, it is necessary to use init_main_module=False.
+        code = """if True:
+            from loky import get_reusable_executor
+            from loky.cloudpickle_wrapper import wrap_non_picklable_objects
+
+            @wrap_non_picklable_objects
+            def test_func(x):
+                return x
+
+            @wrap_non_picklable_objects
+            class Test:
+                def __init__(self):
+                    self.x = 42
+
+                def return_func(self):
+                    return self.x
+
+            test_obj = Test()
+            # Make sure the function and object behave correctly
+            assert test_obj.x == 42
+            assert test_func(42) == 42
+            assert test_obj.return_func() == 42
+            assert test_func(Test().return_func)() == 42
+
+            # Make sure it is picklable even when the executor does not rely on
+            # cloudpickle.
+            e = get_reusable_executor()
+            result_obj = e.submit(test_func, test_obj).result()
+            assert result_obj.return_func() == 42
+
+            print("ok")
+        """
+        cmd = [sys.executable]
+        try:
+            fid, filename = mkstemp(suffix="_joblib.py")
+            os.close(fid)
+            with open(filename, mode='wb') as f:
+                f.write(code.encode('ascii'))
+            cmd += [filename]
+            check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10,
+                                  env={'LOKY_PICKLER': 'pickle'})
+        finally:
+            os.unlink(filename)

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -104,11 +104,13 @@ class TestCloudpickleWrapper:
             assert test_obj.x == 42
             assert test_func(42) == 42
             assert test_obj.return_func() == 42
-            assert test_func(Test().return_func)() == 42
+            assert test_func(test_obj.return_func)() == 42
 
             # Make sure it is picklable even when the executor does not rely on
             # cloudpickle.
             e = get_reusable_executor()
+            result_obj = e.submit(test_func, 42).result()
+            result_obj = e.submit(id, test_obj).result()
             result_obj = e.submit(test_func, test_obj).result()
             assert result_obj.return_func() == 42
 

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -36,9 +36,10 @@ class TestCloudpickleWrapper:
             # Makes sure that if LOKY_PICKLER is set to default pickle, the
             # tasks are not wrapped with cloudpickle and it is not possible
             # using functions from the main module.
+            env = os.environ.copy()
+            env['LOKY_PICKLER'] = 'pickle'
             with pytest.raises(ValueError, match=r'A task has failed to un-s'):
-                check_subprocess_call(cmd, timeout=10,
-                                      env={'LOKY_PICKLER': 'pickle'})
+                check_subprocess_call(cmd, timeout=10, env=env)
         finally:
             os.unlink(filename)
 
@@ -79,10 +80,8 @@ class TestCloudpickleWrapper:
             os.unlink(filename)
 
     def test_cloudpickle_flag_wrapper(self):
-        # check that the init_main_module parameter works properly
-        # when using -c option, we don't need the safeguard if __name__ ..
-        # and thus test LokyProcess without the extra argument. For running
-        # a script, it is necessary to use init_main_module=False.
+        # check that the wrap_non_picklable_objects works properly on functions
+        # and classes.
         code = """if True:
             import pytest
             from loky import get_reusable_executor
@@ -131,7 +130,9 @@ class TestCloudpickleWrapper:
             with open(filename, mode='wb') as f:
                 f.write(code.encode('ascii'))
             cmd += [filename]
-            check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10,
-                                  env={'LOKY_PICKLER': 'pickle'})
+
+            env = os.environ.copy()
+            env['LOKY_PICKLER'] = 'pickle'
+            check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10, env=env)
         finally:
             os.unlink(filename)

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -36,8 +36,7 @@ class TestCloudpickleWrapper:
             # Makes sure that if LOKY_PICKLER is set to default pickle, the
             # tasks are not wrapped with cloudpickle and it is not possible
             # using functions from the main module.
-            env = os.environ.copy()
-            env['LOKY_PICKLER'] = 'pickle'
+            env = {'LOKY_PICKLER': 'pickle'}
             with pytest.raises(ValueError, match=r'A task has failed to un-s'):
                 check_subprocess_call(cmd, timeout=10, env=env)
         finally:

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -130,8 +130,7 @@ class TestCloudpickleWrapper:
                 f.write(code.encode('ascii'))
             cmd += [filename]
 
-            env = os.environ.copy()
-            env['LOKY_PICKLER'] = 'pickle'
+            env = {'LOKY_PICKLER': 'pickle'}
             check_subprocess_call(cmd, stdout_regex=r'ok', timeout=10, env=env)
         finally:
             os.unlink(filename)

--- a/tests/test_cloudpickle_wrapper.py
+++ b/tests/test_cloudpickle_wrapper.py
@@ -162,9 +162,9 @@ class TestCloudpickleWrapper:
                     "Expected CloudPickler and got {{}}"
                     .format(current_loky_pickler))
             else:
-                assert current_loky_pickler == 'Pickler', (
-                    "Expected Pickler and got {{}}"
-                    .format(current_loky_pickler))
+                assert current_loky_pickler == Pickler.__name__, (
+                    "Expected {{}} and got {{}}"
+                    .format(Pickler.__name__, current_loky_pickler))
 
             if loky_pickler in ['cloudpickle', 'pickle']:
                 assert not use_cloudpickle_wrapper()
@@ -175,7 +175,7 @@ class TestCloudpickleWrapper:
             # set_loky_pickler is used without arguments
             set_loky_pickler()
             current_loky_pickler = get_loky_pickler()
-            assert current_loky_pickler == 'Pickler', (
+            assert current_loky_pickler == Pickler.__name__, (
                 "default got loky_pickler={{}}".format(current_loky_pickler))
             assert use_cloudpickle_wrapper()
 

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -6,7 +6,6 @@ import psutil
 import pytest
 import warnings
 import threading
-import weakref
 from time import sleep
 from tempfile import mkstemp
 from multiprocessing import util, current_process
@@ -744,5 +743,3 @@ class TestExecutorInitializer(ReusableExecutorMixin):
         executor = get_reusable_executor(max_workers=4)
         for x in executor.map(self._test_initializer, delay=.1):
             assert x == 'uninitialized'
-
-

--- a/tests/test_worker_timeout.py
+++ b/tests/test_worker_timeout.py
@@ -8,7 +8,7 @@ from loky.backend import get_context
 from loky import ProcessPoolExecutor
 from loky import get_reusable_executor
 from loky.backend.queues import SimpleQueue
-from loky.backend.reduction import CustomizableLokyPickler
+from loky.backend.reduction import dumps
 
 
 class SlowlyPickling(object):
@@ -52,7 +52,7 @@ class DelayedSimpleQueue(SimpleQueue):
     @staticmethod
     def _feed(readlock, reader, writer, delay):
 
-        PICKLE_NONE = CustomizableLokyPickler.dumps(None)
+        PICKLE_NONE = dumps(None)
 
         while True:
             with readlock:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,7 +103,6 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
 
         if sys.version_info[0] >= 3:
             stdout, stderr = stdout.decode(), stderr.decode()
-        print(stdout)
         if proc.returncode == -9:
             message = (
                 'Subprocess timeout after {}s.\nStdout:\n{}\n'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -78,14 +78,14 @@ def id_sleep(x, delay=0):
 
 
 def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
-                          stderr_regex=None):
+                          stderr_regex=None, env=None):
     """Runs a command in a subprocess with timeout in seconds.
 
     Also checks returncode is zero, stdout if stdout_regex is set, and
     stderr if stderr_regex is set.
     """
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+                            stderr=subprocess.PIPE, env=env)
 
     def kill_process():
         warnings.warn("Timeout running {}".format(cmd))
@@ -98,6 +98,7 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
 
         if sys.version_info[0] >= 3:
             stdout, stderr = stdout.decode(), stderr.decode()
+        print(stdout)
         if proc.returncode == -9:
             message = (
                 'Subprocess timeout after {}s.\nStdout:\n{}\n'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import re
+import os
 import sys
 import time
 import warnings
@@ -84,6 +85,10 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
     Also checks returncode is zero, stdout if stdout_regex is set, and
     stderr if stderr_regex is set.
     """
+    if env is not None:
+        env_ = os.environ.copy()
+        env_.update(env)
+        env = env_
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, env=env)
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ basepython =
      py37: {env:TOXPYTHON:python3.7}
      pypy3: {env:TOXPYTHON:pypy3}
 passenv = NUMBER_OF_PROCESSORS
+usedevelop = True
 deps =
      pytest
      pytest-timeout


### PR DESCRIPTION
Add a wrapper for non-picklable objects to use `cloudpickle` for their serialization.

This PR also add a test for `cloudpickle_wrapper.py` to ensure its behavior is working as expected.