### PR TITLE
FIX thread safety of looping on processes

### DIFF
--- a/loky/backend/utils.py
+++ b/loky/backend/utils.py
@@ -127,11 +127,11 @@ def get_exitcodes_terminated_worker(processes):
     # Catch the exitcode of the terminated workers. There should at least be
     # one. If not, wait a bit for the system to correctly set the exitcode of
     # the terminated worker.
-    exitcodes = [p.exitcode for p in processes.values()
+    exitcodes = [p.exitcode for p in list(processes.values())
                  if p.exitcode is not None]
     while len(exitcodes) == 0 and patience > 0:
         patience -= 1
-        exitcodes = [p.exitcode for p in processes.values()
+        exitcodes = [p.exitcode for p in list(processes.values())
                      if p.exitcode is not None]
         time.sleep(.05)
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -611,7 +611,7 @@ def _queue_management_worker(executor_reference,
         # signal send. The wake up signals come either from new tasks being
         # submitted, from the executor being shutdown/gc-ed, or from the
         # shutdown of the python interpreter.
-        worker_sentinels = [p.sentinel for p in processes.values()]
+        worker_sentinels = [p.sentinel for p in list(processes.values())]
         ready = wait(readers + worker_sentinels)
 
         broken = ("A worker process managed by the executor was unexpectedly "


### PR DESCRIPTION
Looping on values of a dict is not thread-safe. However, it is thread safe to loop on `list(d.values())`, as shown by the following snippet

```python
import time

a = dict([(i, i) for i in range(1000000)])

def rm_elem(a):
    for i in range(1000):
        time.sleep(.001)
        del a[i]
    print("done")
    
import threading
t = threading.Thread(target=rm_elem, args=(a,))
t.start()
for i in range(100):
    time.sleep(.001)
    [v for v in list(a.values())]
```

Replacing `[v for v in list(a.values())]` by `[v for v in a.values()]` makes the snippet fails on both `python` and `pypy`.


Close #190 