### PR TITLE
Add test for nested interactively defined functions with code changes

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ import warnings
 import threading
 import subprocess
 import contextlib
+from tempfile import mkstemp
 
 if sys.version_info[0] == 2:
     class TimeoutError(OSError):
@@ -130,6 +131,19 @@ def check_subprocess_call(cmd, timeout=1, stdout_regex=None,
 
     finally:
         timer.cancel()
+
+
+def check_python_subprocess_call(code, stdout_regex=None):
+    cmd = [sys.executable]
+    try:
+        fid, filename = mkstemp(suffix="_joblib.py")
+        os.close(fid)
+        with open(filename, mode='wb') as f:
+            f.write(code.encode('ascii'))
+        cmd += [filename]
+        check_subprocess_call(cmd, stdout_regex=stdout_regex, timeout=10)
+    finally:
+        os.unlink(filename)
 
 
 def filter_match(match, start_method=None):


### PR DESCRIPTION
This test should fail with any release of cloudpickle after 0.5.4 up to the current stable release (0.7.0 at this time).

I tested locally that https://github.com/cloudpipe/cloudpickle/pull/240 makes it pass.

I believe this further highlights that the change introduced in cloudpickle 0.5.4 is actually a bug.