### PR TITLE
FIX  _pid attribute passing of semaphore_tracker 

### DIFF
--- a/loky/backend/context.py
+++ b/loky/backend/context.py
@@ -211,8 +211,8 @@ class LokyContext(BaseContext):
         """
         def Semaphore(self, value=1):
             """Returns a semaphore object"""
-            from . import synchronize
-            return synchronize.Semaphore(value=value)
+            from .synchronize import Semaphore
+            return Semaphore(value=value)
 
         def BoundedSemaphore(self, value):
             """Returns a bounded semaphore object"""

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -99,7 +99,6 @@ class SemaphoreTracker(object):
                         args[i] = re.sub("-R+", "-R", args[i])
                 args += ['-c', cmd % r]
                 util.debug("launching Semaphore tracker: {}".format(args))
-                pid = spawnv_passfds(exe, args, fds_to_pass)
                 # bpo-33613: Register a signal mask that will block the
                 # signals.  This signal mask will be inherited by the child
                 # that is going to be spawned and will protect the child from a
@@ -110,7 +109,7 @@ class SemaphoreTracker(object):
                     if _HAVE_SIGMASK:
                         signal.pthread_sigmask(signal.SIG_BLOCK,
                                                _IGNORED_SIGNALS)
-                    pid = util.spawnv_passfds(exe, args, fds_to_pass)
+                    pid = spawnv_passfds(exe, args, fds_to_pass)
                 finally:
                     if _HAVE_SIGMASK:
                         signal.pthread_sigmask(signal.SIG_UNBLOCK,

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -75,8 +75,8 @@ class SemaphoreTracker(object):
                     # Clean-up to avoid dangling processes.
                     os.waitpid(self._pid, 0)
                 except OSError:
-                    # The process terminated or is a child from an ancestor of
-                    # the current process.
+                    # The process was terminated or is a child from an ancestor
+                    # of the current process.
                     pass
                 self._fd = None
                 self._pid = None

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -74,6 +74,7 @@ class SemaphoreTracker(object):
                 self._fd = None
                 self._pid = None
 
+                warnings.filterwarnings('always', module=__name__)
                 warnings.warn('semaphore_tracker: process died unexpectedly, '
                               'relaunching.  Some semaphores might leak.')
 
@@ -230,7 +231,7 @@ def main(fd):
                                          .format(name))
                         sys.stderr.flush()
                 except Exception as e:
-                    warnings.warn('semaphore_tracker: %r: %r' % (name, e))
+                    warnings.warn('semaphore_tracker: %s: %r' % (name, e))
             finally:
                 pass
 

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -134,8 +134,6 @@ class SemaphoreTracker(object):
     def _check_alive(self):
         '''Check for the existence of the semaphore tracker process.'''
         try:
-            # We cannot use send here as it calls ensure_running, creating
-            # a cycle.
             self._send('PROBE', '')
         except BrokenPipeError:
             return False

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -132,11 +132,11 @@ class SemaphoreTracker(object):
                 os.close(r)
 
     def _check_alive(self):
-        '''Check for that the pipe has not been closed by sending a probe.'''
+        '''Check for the existence of the semaphore tracker process.'''
         try:
             # We cannot use send here as it calls ensure_running, creating
             # a cycle.
-            os.write(self._fd, b'PROBE:0\n')
+            self._send('PROBE', '')
         except BrokenPipeError:
             return False
         else:

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -84,7 +84,8 @@ class SemaphoreTracker(object):
             except Exception:
                 pass
 
-            cmd = 'from {} import main; main(%d)'.format(main.__module__)
+            cmd = 'from {} import main; main(%d, %d)'.format(main.__module__,
+                                                             int(VERBOSE))
             r, w = os.pipe()
             try:
                 fds_to_pass.append(r)
@@ -98,7 +99,7 @@ class SemaphoreTracker(object):
                     import re
                     for i in range(1, len(args)):
                         args[i] = re.sub("-R+", "-R", args[i])
-                args += ['-c', cmd % r]
+                args += ['-c', cmd % (r, VERBOSE)]
                 util.debug("launching Semaphore tracker: {}".format(args))
                 # bpo-33613: Register a signal mask that will block the
                 # signals.  This signal mask will be inherited by the child
@@ -160,7 +161,7 @@ unregister = _semaphore_tracker.unregister
 getfd = _semaphore_tracker.getfd
 
 
-def main(fd):
+def main(fd, verbose=0):
     '''Run semaphore tracker.'''
     # protect the process from ^C and "killall python" etc
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -175,7 +176,7 @@ def main(fd):
         except Exception:
             pass
 
-    if VERBOSE:  # pragma: no cover
+    if verbose:  # pragma: no cover
         sys.stderr.write("Main semaphore tracker is running\n")
         sys.stderr.flush()
 
@@ -189,14 +190,14 @@ def main(fd):
                     if cmd == b'REGISTER':
                         name = name.decode('ascii')
                         cache.add(name)
-                        if VERBOSE:  # pragma: no cover
+                        if verbose:  # pragma: no cover
                             sys.stderr.write("[SemaphoreTracker] register {}\n"
                                              .format(name))
                             sys.stderr.flush()
                     elif cmd == b'UNREGISTER':
                         name = name.decode('ascii')
                         cache.remove(name)
-                        if VERBOSE:  # pragma: no cover
+                        if verbose:  # pragma: no cover
                             sys.stderr.write("[SemaphoreTracker] unregister {}"
                                              ": cache({})\n"
                                              .format(name, len(cache)))
@@ -226,7 +227,7 @@ def main(fd):
             try:
                 try:
                     sem_unlink(name)
-                    if VERBOSE:  # pragma: no cover
+                    if verbose:  # pragma: no cover
                         sys.stderr.write("[SemaphoreTracker] unlink {}\n"
                                          .format(name))
                         sys.stderr.flush()
@@ -235,7 +236,7 @@ def main(fd):
             finally:
                 pass
 
-    if VERBOSE:  # pragma: no cover
+    if verbose:  # pragma: no cover
         sys.stderr.write("semaphore tracker shut down\n")
         sys.stderr.flush()
 

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -74,7 +74,6 @@ class SemaphoreTracker(object):
                 self._fd = None
                 self._pid = None
 
-                warnings.filterwarnings('always', module=__name__)
                 warnings.warn('semaphore_tracker: process died unexpectedly, '
                               'relaunching.  Some semaphores might leak.')
 

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -90,9 +90,9 @@ class SemaphoreTracker(object):
             except Exception:
                 pass
 
-            cmd = 'from {} import main; main(%d, %d)'.format(main.__module__,
-                                                             int(VERBOSE))
             r, w = os.pipe()
+            cmd = 'from {} import main; main({}, {})'.format(
+                main.__module__, r, VERBOSE)
             try:
                 fds_to_pass.append(r)
                 # process will out live us, so no need to wait on pid
@@ -105,7 +105,7 @@ class SemaphoreTracker(object):
                     import re
                     for i in range(1, len(args)):
                         args[i] = re.sub("-R+", "-R", args[i])
-                args += ['-c', cmd % (r, VERBOSE)]
+                args += ['-c', cmd]
                 util.debug("launching Semaphore tracker: {}".format(args))
                 # bpo-33613: Register a signal mask that will block the
                 # signals.  This signal mask will be inherited by the child

--- a/loky/backend/semaphore_tracker.py
+++ b/loky/backend/semaphore_tracker.py
@@ -37,7 +37,7 @@ except ImportError:
     from .semlock import sem_unlink
 
 if sys.version_info < (3,):
-    BrokenPipeError = IOError
+    BrokenPipeError = OSError
 
 __all__ = ['ensure_running', 'register', 'unregister']
 

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -151,7 +151,7 @@ def prepare(data):
     if 'orig_dir' in data:
         process.ORIGINAL_DIR = data['orig_dir']
 
-    if 'tacker_pid' in data:
+    if 'tracker_pid' in data:
         from . import semaphore_tracker
         semaphore_tracker._semaphore_tracker._pid = data["tracker_pid"]
 

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -26,8 +26,6 @@ class TestSemaphoreTracker:
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="no semaphore_tracker on windows")
-    @pytest.mark.skipif(sys.version_info[:2] < (3, 3),
-                        reason="multiprocessing spawn context not available")
     def test_child_retrieves_semaphore_tracker(self):
         parent_sem_tracker_pid = get_sem_tracker_pid()
         executor = ProcessPoolExecutor(max_workers=2)
@@ -40,66 +38,51 @@ class TestSemaphoreTracker:
         # child process. If the two processes do not share the same
         # semaphore_tracker, a cache KeyError should be printed in stderr.
         import subprocess
-        r, w = os.pipe()
+        lname = 'loky-mysemaphore'
         cmd = '''if 1:
         import os, sys
-        import multiprocessing as mp
 
         from loky import ProcessPoolExecutor
         from loky.backend import semaphore_tracker
+        from loky.backend.semlock import SemLock
 
         semaphore_tracker.VERBOSE=True
+        lname = "{}"
 
-        os.close(%d)
-
-        # The benefit of using multiprocessing locks in this test is that they
-        # do not trigger custom un-registration callbacks during garabge
-        # collection.
-        # Therefore, un-registering the lock manually as we do here will not
-        # pollute the stderr pipe with a cache KeyError afterwards.
-        lock = mp.get_context("spawn").Lock()
-        name = lock._semlock.name
-        semaphore_tracker.register(name)
+        # The benefit of using _SemLock objects in this test is that they do
+        # not trigger custom un-registration callbacks during garabge
+        # collection. Therefore, un-registering the lock manually as we do
+        # here will not pollute the stderr pipe with a cache KeyError
+        # afterwards.
+        lock = SemLock(1, 1, 1, name=lname)
+        semaphore_tracker.register(lname)
 
         def unregister(name):
             # semaphore_tracker.unregister is actually a bound method of the
             # SemaphoreTracker. We need a custom wrapper to avoid object
             # serialization.
             from loky.backend import semaphore_tracker
-            semaphore_tracker.unregister(name)
+            semaphore_tracker.unregister(lname)
 
         e = ProcessPoolExecutor(1)
-        e.submit(unregister, name).result()
-
-        from multiprocessing import semaphore_tracker
-        from _multiprocessing import sem_unlink
-        semaphore_tracker.unregister(name)
-        sem_unlink(name)
-
+        e.submit(unregister, lname).result()
         e.shutdown()
-        os.write(%d, name.encode("ascii") + b"\\n")
         '''
-        if sys.version_info[:2] >= (3, 2):
-            fd_kws = {'pass_fds': [w, r]}
-        else:
-            fd_kws = {'close_fds': False}
+        try:
+            p = subprocess.Popen(
+                [sys.executable, '-E', '-c', cmd.format(lname)],
+                stderr=subprocess.PIPE)
+            p.wait()
 
-        p = subprocess.Popen([sys.executable, '-E', '-c', cmd % (r, w)],
-                             stderr=subprocess.PIPE, **fd_kws)
+            err = p.stderr.read().decode('utf-8')
+            p.stderr.close()
 
-        os.close(w)
-        with io.open(r, 'rb', closefd=True) as f:
-            name1 = f.readline().rstrip().decode('ascii')
+            assert re.search("unregister %s" % lname, err) is not None
+            assert re.search("KeyError: '%s'" % lname, err) is None
 
-        p.terminate()
-        p.wait()
-        time.sleep(1.0)
+        finally:
+            sem_unlink(lname)
 
-        err = p.stderr.read().decode('utf-8')
-        p.stderr.close()
-
-        assert re.search('unregister %s' % name1, err) is not None
-        assert re.search("KeyError: '%s'" % name1, err) is None
 
     # The following four tests are inspired from cpython _test_multiprocessing
     @pytest.mark.skipif(sys.platform == "win32",

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -188,7 +188,6 @@ class TestSemaphoreTracker:
                 assert "semaphore_tracker: process died" in str(
                     the_warn.message)
             else:
-                print(all_warn)
                 assert len(all_warn) == 0
 
     @pytest.mark.skipif(sys.platform == "win32",

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -1,6 +1,18 @@
 """Tests for the SemaphoreTracker class"""
+import errno
+import gc
+import os
+import re
+import signal
+import sys
+import time
+import warnings
+import weakref
+
 from loky import ProcessPoolExecutor
 import loky.backend.semaphore_tracker as semaphore_tracker
+from loky.backend.semlock import sem_unlink
+from loky.backend.context import get_context
 
 
 def get_sem_tracker_pid():
@@ -17,3 +29,100 @@ class TestSemaphoreTracker:
         executor = ProcessPoolExecutor(max_workers=2)
         child_sem_tracker_pid = executor.submit(get_sem_tracker_pid).result()
         assert child_sem_tracker_pid == parent_sem_tracker_pid
+
+    # The following four tests are inspired from cpython _test_multiprocessing
+    def test_semaphore_tracker(self):
+        #
+        # Check that killing process does not leak named semaphores
+        #
+        import subprocess
+        cmd = '''if 1:
+            import multiprocessing as mp, time, os
+            mp.set_start_method("spawn")
+            lock1 = mp.Lock()
+            lock2 = mp.Lock()
+            os.write(%d, lock1._semlock.name.encode("ascii") + b"\\n")
+            os.write(%d, lock2._semlock.name.encode("ascii") + b"\\n")
+            time.sleep(10)
+        '''
+        r, w = os.pipe()
+        p = subprocess.Popen([sys.executable,
+                             '-E', '-c', cmd % (w, w)],
+                             pass_fds=[w],
+                             stderr=subprocess.PIPE)
+        os.close(w)
+        with open(r, 'rb', closefd=True) as f:
+            name1 = f.readline().rstrip().decode('ascii')
+            name2 = f.readline().rstrip().decode('ascii')
+
+        # subprocess holding a reference to lock1 is still alive, so this call
+        # should succeed
+        sem_unlink(name1)
+        p.terminate()
+        p.wait()
+        time.sleep(2.0)
+        with self.assertRaises(OSError) as ctx:
+            sem_unlink(name2)
+        # docs say it should be ENOENT, but OSX seems to give EINVAL
+        self.assertIn(ctx.exception.errno, (errno.ENOENT, errno.EINVAL))
+        err = p.stderr.read().decode('utf-8')
+        p.stderr.close()
+        expected = re.compile(
+            'semaphore_tracker: There appear to be 2 leaked semaphores')
+        assert expected.match(err) is not None
+
+        # lock1 is still registered, but was destroyed externally: the tracker
+        # is expected to complain.
+        expected = re.compile(r'semaphore_tracker: %r: \[Errno' % name1)
+        assert expected.match(err) is not None
+
+    def check_semaphore_tracker_death(self, signum, should_die):
+        # bpo-31310: if the semaphore tracker process has died, it should
+        # be restarted implicitly.
+        from loky.backend.semaphore_tracker import _semaphore_tracker
+        # _semaphore_tracker.ensure_running()
+        pid = _semaphore_tracker._pid
+        if pid is not None:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _semaphore_tracker.ensure_running()
+        pid = _semaphore_tracker._pid
+
+        os.kill(pid, signum)
+        time.sleep(1.0)  # give it time to die
+
+        ctx = get_context("loky")
+        with warnings.catch_warnings(record=True) as all_warn:
+            warnings.simplefilter("always")
+            sem = ctx.Semaphore()
+            sem.acquire()
+            sem.release()
+            wr = weakref.ref(sem)
+            # ensure `sem` gets collected, which triggers communication with
+            # the semaphore tracker
+            del sem
+            gc.collect()
+            assert wr() is None
+            if should_die:
+                assert len(all_warn) == 1
+                the_warn = all_warn[0]
+                assert issubclass(the_warn.category, UserWarning)
+                assert "semaphore_tracker: process died" in str(
+                    the_warn.message)
+            else:
+                print(all_warn)
+                assert len(all_warn) == 0
+
+    def test_semaphore_tracker_sigint(self):
+        # Catchable signal (ignored by semaphore tracker)
+        self.check_semaphore_tracker_death(signal.SIGINT, False)
+
+    def test_semaphore_tracker_sigterm(self):
+        # Catchable signal (ignored by semaphore tracker)
+        self.check_semaphore_tracker_death(signal.SIGTERM, False)
+
+    def test_semaphore_tracker_sigkill(self):
+        # Uncatchable signal.
+        self.check_semaphore_tracker_death(signal.SIGKILL, True)

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -44,12 +44,9 @@ class TestSemaphoreTracker:
         semaphore_tracker.VERBOSE=True
         semlock_name = "{}"
 
-        # The benefit of using _SemLock objects in this test is that they do
-        # not trigger custom un-registration callbacks during garbage
-        # collection. Therefore, un-registering the lock manually as we do
-        # here will not pollute the stderr pipe with a cache KeyError
-        # afterwards.
-        lock = SemLock(1, 1, 1, name=semlock_name)
+        # We don't need to create the semaphore as registering / unregistering
+        # operations simply add / remove entries from a cache, but do not
+        # manipulate the actual semaphores.
         semaphore_tracker.register(semlock_name)
 
         def unregister(name):
@@ -82,7 +79,6 @@ class TestSemaphoreTracker:
             assert re.search("KeyError: '%s'" % semlock_name, err) is None
 
         finally:
-            sem_unlink(semlock_name)
             executor.shutdown()
 
 

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -22,10 +22,9 @@ def get_sem_tracker_pid():
     return semaphore_tracker._semaphore_tracker._pid
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="no semaphore_tracker on windows")
 class TestSemaphoreTracker:
-
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="no semaphore_tracker on windows")
     def test_child_retrieves_semaphore_tracker(self):
         parent_sem_tracker_pid = get_sem_tracker_pid()
         executor = ProcessPoolExecutor(max_workers=2)
@@ -85,8 +84,6 @@ class TestSemaphoreTracker:
 
 
     # The following four tests are inspired from cpython _test_multiprocessing
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker(self):
         #
         # Check that killing process does not leak named semaphores
@@ -188,20 +185,14 @@ class TestSemaphoreTracker:
             else:
                 assert len(all_warn) == 0
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker_sigint(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGINT, False)
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker_sigterm(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGTERM, False)
 
-    @pytest.mark.skipif(sys.platform == "win32",
-                        reason="no semaphore_tracker on windows")
     @pytest.mark.skipif(sys.version_info[0] < 3,
                         reason="warnings.catch_warnings limitation")
     def test_semaphore_tracker_sigkill(self):

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -1,0 +1,19 @@
+"""Tests for the SemaphoreTracker class"""
+from loky import ProcessPoolExecutor
+import loky.backend.semaphore_tracker as semaphore_tracker
+
+
+def get_sem_tracker_pid():
+    semaphore_tracker.ensure_running()
+    return semaphore_tracker._semaphore_tracker._pid
+
+
+class TestSemaphoreTracker:
+    def tests_child_retrieves_semaphore_tracker(self):
+        # Worker processes created with loky should retrieve the
+        # semaphore_tracker of their parent. This is tested by an equality
+        # check on the tracker's process id.
+        parent_sem_tracker_pid = get_sem_tracker_pid()
+        executor = ProcessPoolExecutor(max_workers=2)
+        child_sem_tracker_pid = executor.submit(get_sem_tracker_pid).result()
+        assert child_sem_tracker_pid == parent_sem_tracker_pid

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -147,7 +147,6 @@ class TestSemaphoreTracker:
         # bpo-31310: if the semaphore tracker process has died, it should
         # be restarted implicitly.
         from loky.backend.semaphore_tracker import _semaphore_tracker
-        # _semaphore_tracker.ensure_running()
         pid = _semaphore_tracker._pid
         if pid is not None:
             os.kill(pid, signal.SIGKILL)

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -113,6 +113,11 @@ class TestSemaphoreTracker:
         ctx = get_context("loky")
         with warnings.catch_warnings(record=True) as all_warn:
             warnings.simplefilter("always")
+
+            # remove unrelated MacOS warning messages first
+            warnings.filterwarnings(
+                "ignore", message='semaphore are broken on OSX')
+
             sem = ctx.Semaphore()
             sem.acquire()
             sem.release()

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -204,6 +204,8 @@ class TestSemaphoreTracker:
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="no semaphore_tracker on windows")
+    @pytest.mark.skipif(sys.version_info[0] < 3,
+                        reason="warnings.catch_warnings limitation")
     def test_semaphore_tracker_sigkill(self):
         # Uncatchable signal.
         self.check_semaphore_tracker_death(signal.SIGKILL, True)

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -155,9 +155,8 @@ class TestSemaphoreTracker:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             _semaphore_tracker.ensure_running()
-            # in python2.7, the race condition described in bpo-33613 still
-            # exists.
-            # TODO: prevent race condition in python2.7?
+            # in python < 3.3 , the race condition described in bpo-33613 still
+            # exists, as this fixe requires signal.pthread_sigmask
             time.sleep(1.0)
         pid = _semaphore_tracker._pid
 

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -23,6 +23,9 @@ def get_sem_tracker_pid():
 
 
 class TestSemaphoreTracker:
+
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no semaphore_tracker on windows")
     def tests_child_retrieves_semaphore_tracker(self):
         # Worker processes created with loky should retrieve the
         # semaphore_tracker of their parent. This is tested by an equality
@@ -33,6 +36,8 @@ class TestSemaphoreTracker:
         assert child_sem_tracker_pid == parent_sem_tracker_pid
 
     # The following four tests are inspired from cpython _test_multiprocessing
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker(self):
         #
         # Check that killing process does not leak named semaphores
@@ -137,14 +142,20 @@ class TestSemaphoreTracker:
                 print(all_warn)
                 assert len(all_warn) == 0
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker_sigint(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGINT, False)
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker_sigterm(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGTERM, False)
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="no semaphore_tracker on windows")
     def test_semaphore_tracker_sigkill(self):
         # Uncatchable signal.
         self.check_semaphore_tracker_death(signal.SIGKILL, True)


### PR DESCRIPTION
Closes #200.
At the end, the passing of the `_pid` attribute was implemented, but there was a typo.
Adding a test alongside with it.