### PR TITLE
FIX do not override Pickler's dispatch_table

### DIFF
--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -188,7 +188,11 @@ def set_loky_pickler(loky_pickler=None):
             if sys.version_info < (3,):
                 self.dispatch = self._dispatch.copy()
             else:
-                self.dispatch_table = self._dispatch_table.copy()
+                if getattr(self, "dispatch_table", None) is not None:
+                    self.dispatch_table.update(self._dispatch_table.copy())
+                else:
+                    self.dispatch_table = self._dispatch_table.copy()
+
             for type, reduce_func in reducers.items():
                 self.register(type, reduce_func)
 


### PR DESCRIPTION
If a `Pickler` instance already has methods in its dispatch table, do not override them. This bug showed up in https://github.com/cloudpipe/cloudpickle/pull/253 and running [this benchmark](https://gist.github.com/pierreglaser/26207c20dd8526d6df7963044a3e4477) where the `Cloudpickler` instances derives from the C `_Pickler` and most custom saving methods are inside `dispatch_table`, not `dispatch`.

Given the current `set_loky_pickler` structure (private, nested `CustomizablePickler` class), it is hard to write a proper test for it.