### PR TITLE
ENH add ResourceTracker to improve ressource clean up

### DIFF
--- a/loky/backend/compat_win32.py
+++ b/loky/backend/compat_win32.py
@@ -34,19 +34,6 @@ if sys.platform == "win32":
             CreateProcess = win_api.CreateProcess
 
             @staticmethod
-            def CreatePipe(*args):
-                rfd, wfd = os.pipe()
-                _current_process = win_api.GetCurrentProcess()
-                rhandle = win_api.DuplicateHandle(
-                    _current_process, msvcrt.get_osfhandle(rfd),
-                    _current_process, 0, True,
-                    win_api.DUPLICATE_SAME_ACCESS)
-                if sys.version_info[:2] < (3, 3):
-                    rhandle = rhandle.Detach()
-                os.close(rfd)
-                return rhandle, wfd
-
-            @staticmethod
             def CloseHandle(h):
                 if isinstance(h, numbers.Integral):
                     # Cast long to int for 64-bit Python 2.7 under Windows

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -17,7 +17,7 @@ if sys.version_info[:2] < (3, 3):
     ProcessLookupError = OSError
 
 if sys.platform != "win32":
-    from . import semaphore_tracker
+    from . import resource_tracker
 
 
 __all__ = []
@@ -121,7 +121,7 @@ if sys.platform != "win32":
 
         def _launch(self, process_obj):
 
-            tracker_fd = semaphore_tracker._semaphore_tracker.getfd()
+            tracker_fd = resource_tracker._resource_tracker.getfd()
 
             fp = BytesIO()
             set_spawning_popen(self)
@@ -147,9 +147,7 @@ if sys.platform != "win32":
                 cmd_python += ['--pipe',
                                str(reduction._mk_inheritable(child_r))]
                 reduction._mk_inheritable(child_w)
-                if tracker_fd is not None:
-                    cmd_python += ['--semaphore',
-                                   str(reduction._mk_inheritable(tracker_fd))]
+                reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
                 from .fork_exec import fork_exec
                 pid = fork_exec(cmd_python, self._fds)
@@ -180,15 +178,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('Command line parser')
     parser.add_argument('--pipe', type=int, required=True,
                         help='File handle for the pipe')
-    parser.add_argument('--semaphore', type=int, required=True,
-                        help='File handle name for the semaphore tracker')
     parser.add_argument('--process-name', type=str, default=None,
                         help='Identifier for debugging purpose')
 
     args = parser.parse_args()
 
     info = dict()
-    semaphore_tracker._semaphore_tracker._fd = args.semaphore
 
     exitcode = 1
     try:

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -99,52 +99,47 @@ class Popen(_Popen):
         return reduction.duplicate(handle, self.sentinel)
 
 
-if sys.version_info[:2] >= (3, 8):
-    from multiprocessing.spawn import get_command_line
-else:
-    # compatibility for python2.7. Duplicate here the code from
-    # multiprocessing.forking.main to call our prepare function and correctly
-    # set the default start_methods in loky.
+def get_command_line(pipe_handle, **kwds):
+    '''
+    Returns prefix of command line used for spawning a child process
+    '''
+    if getattr(sys, 'frozen', False):
+        return ([sys.executable, '--multiprocessing-fork', pipe_handle])
+    else:
+        prog = 'from loky.backend.popen_loky_win32 import main; main()'
+        opts = util._args_from_interpreter_flags()
+        return [spawn.get_executable()] + opts + [
+            '-c', prog, '--multiprocessing-fork', pipe_handle]
 
-    def get_command_line(pipe_handle, **kwds):
-        '''
-        Returns prefix of command line used for spawning a child process
-        '''
-        if getattr(sys, 'frozen', False):
-            return ([sys.executable, '--multiprocessing-fork', pipe_handle])
-        else:
-            prog = 'from loky.backend.popen_loky_win32 import main; main()'
-            opts = util._args_from_interpreter_flags()
-            return [spawn.get_executable()] + opts + [
-                '-c', prog, '--multiprocessing-fork', pipe_handle]
 
-    def is_forking(argv):
-        '''
-        Return whether commandline indicates we are forking
-        '''
-        if len(argv) >= 2 and argv[1] == '--multiprocessing-fork':
-            assert len(argv) == 3
-            return True
-        else:
-            return False
+def is_forking(argv):
+    '''
+    Return whether commandline indicates we are forking
+    '''
+    if len(argv) >= 2 and argv[1] == '--multiprocessing-fork':
+        assert len(argv) == 3
+        return True
+    else:
+        return False
 
-    def main():
-        '''
-        Run code specified by data received over pipe
-        '''
-        assert is_forking(sys.argv)
 
-        handle = int(sys.argv[-1])
-        fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
-        from_parent = os.fdopen(fd, 'rb')
+def main():
+    '''
+    Run code specified by data received over pipe
+    '''
+    assert is_forking(sys.argv)
 
-        process.current_process()._inheriting = True
-        preparation_data = load(from_parent)
-        spawn.prepare(preparation_data)
-        self = load(from_parent)
-        process.current_process()._inheriting = False
+    handle = int(sys.argv[-1])
+    fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
+    from_parent = os.fdopen(fd, 'rb')
 
-        from_parent.close()
+    process.current_process()._inheriting = True
+    preparation_data = load(from_parent)
+    spawn.prepare(preparation_data)
+    self = load(from_parent)
+    process.current_process()._inheriting = False
 
-        exitcode = self._bootstrap()
-        exit(exitcode)
+    from_parent.close()
+
+    exitcode = self._bootstrap()
+    exit(exitcode)

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -60,7 +60,7 @@ class Popen(_Popen):
                 # start process
                 try:
                     # This flag allows to pass inheritable handles from the
-                    # child to the parent process in a python2-3 compatible way
+                    # parent to the child process in a python2-3 compatible way
                     # (see
                     # https://github.com/tomMoral/loky/pull/204#discussion_r290719629
                     # for more detail). When support for Python 2 is dropped,

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -96,7 +96,7 @@ class Popen(_Popen):
 
     def duplicate_for_child(self, handle):
         assert self is get_spawning_popen()
-        return reduction.duplicate(handle, self.sentinel)
+        return duplicate(handle, self.sentinel)
 
 
 def get_command_line(pipe_handle, **kwds):

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -59,9 +59,17 @@ class Popen(_Popen):
             with open(wfd, 'wb') as to_child:
                 # start process
                 try:
+                    # This flag allows to pass inheritable handles from the
+                    # child to the parent process in a python2-3 compatible way
+                    # (see
+                    # https://github.com/tomMoral/loky/pull/204#discussion_r290719629
+                    # for more detail). When support for Python 2 is dropped,
+                    # the cleaner multiprocessing.reduction.steal_handle should
+                    # be used instead.
+                    inherit = True
                     hp, ht, pid, tid = _winapi.CreateProcess(
                         spawn.get_executable(), cmd,
-                        None, None, True, 0,
+                        None, None, inherit, 0,
                         None, None, None)
                     _winapi.CloseHandle(ht)
                 except BaseException as e:

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -25,7 +25,7 @@ from pickle import HIGHEST_PROTOCOL
 
 if sys.platform == "win32":
     if sys.version_info[:2] > (3, 3):
-        from multiprocessing.reduction import duplicate
+        from multiprocessing.reduction import duplicate, steal_handle
     else:
         from multiprocessing.forking import duplicate
 
@@ -253,4 +253,4 @@ def dumps(obj, reducers=None, protocol=None):
 __all__ = ["dump", "dumps", "loads", "register", "set_loky_pickler"]
 
 if sys.platform == "win32":
-    __all__ += ["duplicate"]
+    __all__ += ["duplicate", "steal_handle"]

--- a/loky/backend/reduction.py
+++ b/loky/backend/reduction.py
@@ -25,7 +25,7 @@ from pickle import HIGHEST_PROTOCOL
 
 if sys.platform == "win32":
     if sys.version_info[:2] > (3, 3):
-        from multiprocessing.reduction import duplicate, steal_handle
+        from multiprocessing.reduction import duplicate
     else:
         from multiprocessing.forking import duplicate
 
@@ -253,4 +253,4 @@ def dumps(obj, reducers=None, protocol=None):
 __all__ = ["dump", "dumps", "loads", "register", "set_loky_pickler"]
 
 if sys.platform == "win32":
-    __all__ += ["duplicate", "steal_handle"]
+    __all__ += ["duplicate"]

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -44,6 +44,7 @@ except ImportError:
 
 if sys.version_info < (3,):
     BrokenPipeError = OSError
+    from os import fdopen as open
 
 __all__ = ['ensure_running', 'register', 'unregister']
 
@@ -211,7 +212,7 @@ def main(fd, verbose=0):
         # keep track of registered/unregistered resources
         if sys.platform == "win32":
             fd = msvcrt.open_osfhandle(fd, os.O_RDONLY)
-        with os.fdopen(fd, 'rb') as f:
+        with open(fd, 'rb') as f:
             for line in f:
                 try:
                     cmd, rtype, name = line.strip().decode('ascii').split(

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -259,7 +259,7 @@ def main(fd, verbose=0):
             for name in rtype_cache:
                 # For some reason the process which created and registered this
                 # resource has failed to unregister it. Presumably it has
-                # died.  We therefore unlink it.
+                # died.  We therefore clean it up.
                 try:
                     try:
                         _CLEANUP_FUNCS[rtype](name)

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -178,7 +178,7 @@ class ResourceTracker(object):
         self._send('UNREGISTER', name, rtype)
 
     def _send(self, cmd, name, rtype):
-        msg = '{0}:{1}:{2}\n'.format(cmd, name, rtype).encode('ascii')
+        msg = '{0}:{1}:{2}\n'.format(cmd, rtype, name).encode('ascii')
         if len(name) > 512:
             # posix guarantees that writes to a pipe of less than PIPE_BUF
             # bytes are atomic, and that PIPE_BUF >= 512
@@ -227,7 +227,8 @@ def main(fd, verbose=0, parent_pid=None):
         with open(fd, 'rb') as f:
             for line in f:
                 try:
-                    cmd, name, rtype = line.strip().decode('ascii').split(':')
+                    cmd, rtype, name = line.strip().decode('ascii').split(
+                        ':', maxsplit=2)
                     cleanup_func = _CLEANUP_FUNCS.get(rtype, None)
                     if cleanup_func is None:
                         raise ValueError('Cannot register for automatic '

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -107,12 +107,10 @@ class ResourceTracker(object):
             r, w = os.pipe()
 
             if sys.platform == "win32":
-                self._fh = msvcrt.get_osfhandle(w)
                 r = duplicate(msvcrt.get_osfhandle(r), inheritable=True)
 
-
-            cmd = 'from {} import main; main({}, {}, {})'.format(
-                main.__module__, r, VERBOSE, os.getpid())
+            cmd = 'from {} import main; main({}, {})'.format(
+                main.__module__, r, VERBOSE)
             try:
                 fds_to_pass.append(r)
                 # process will out live us, so no need to wait on pid
@@ -191,7 +189,7 @@ unregister = _resource_tracker.unregister
 getfd = _resource_tracker.getfd
 
 
-def main(fd, verbose=0, parent_pid=None):
+def main(fd, verbose=0):
     '''Run resource tracker.'''
     # protect the process from ^C and "killall python" etc
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -298,7 +296,6 @@ def spawnv_passfds(path, args, passfds):
             os.close(errpipe_read)
             os.close(errpipe_write)
     else:
-        # 3.3+ only
         cmd = ' '.join('"%s"' % x for x in args)
         try:
             hp, ht, pid, tid = _winapi.CreateProcess(

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -52,7 +52,8 @@ _HAVE_SIGMASK = hasattr(signal, 'pthread_sigmask')
 _IGNORED_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 
 _CLEANUP_FUNCS = {
-    'folder': shutil.rmtree
+    'folder': shutil.rmtree,
+    'noop': lambda: None
 }
 
 if os.name == "posix":
@@ -155,7 +156,7 @@ class ResourceTracker(object):
     def _check_alive(self):
         '''Check for the existence of the resource tracker process.'''
         try:
-            self._send('PROBE', '', 'folder')
+            self._send('PROBE', '', 'noop')
         except BrokenPipeError:
             return False
         else:

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -84,7 +84,7 @@ def get_preparation_data(name, init_main_module=True):
 
     # Pass the resource_tracker pid to avoid re-spawning it in every child
     from . import resource_tracker
-    # resource_tracker.ensure_running()
+    resource_tracker.ensure_running()
     d['tracker_args'] = {
         'pid': resource_tracker._resource_tracker._pid,
         'fd': resource_tracker.getfd(),
@@ -155,14 +155,13 @@ def prepare(data):
         process.ORIGINAL_DIR = data['orig_dir']
 
     if 'tracker_args' in data:
-        from . import resource_tracker
-        import msvcrt
-        resource_tracker._resource_tracker._pid = data["tracker_args"]['pid']
-        # resource_tracker._resource_tracker._fd = msvcrt.open_osfhandle(
-        #     data["tracker_args"]['fd'], 0)
-        resource_tracker._resource_tracker._fh = data["tracker_args"]['fh']
-        resource_tracker._resource_tracker._fd = msvcrt.open_osfhandle(
-            resource_tracker._resource_tracker._fh, 0)
+        from .resource_tracker import _resource_tracker
+        _resource_tracker._pid = data["tracker_args"]['pid']
+        if sys.platform == 'win32':
+            _resource_tracker._fh = data["tracker_args"]['fh']
+        else:
+            _resource_tracker._fd = data["tracker_args"]['fd']
+
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -88,7 +88,7 @@ def get_preparation_data(name, init_main_module=True):
     d['tracker_args'] = {
         'pid': resource_tracker._resource_tracker._pid,
         'fd': resource_tracker.getfd(),
-        'fh': resource_tracker._resource_tracker._fh
+        'fh': getattr(resource_tracker._resource_tracker, "_fh", None)
     }
 
     # Figure out whether to initialise main in the subprocess as a module

--- a/loky/backend/synchronize.py
+++ b/loky/backend/synchronize.py
@@ -18,7 +18,7 @@ import _multiprocessing
 from time import time as _time
 
 from .context import assert_spawning
-from . import semaphore_tracker
+from . import resource_tracker
 from multiprocessing import process
 from multiprocessing import util
 
@@ -87,14 +87,14 @@ class SemLock(object):
 
         # When the object is garbage collected or the
         # process shuts down we unlink the semaphore name
-        semaphore_tracker.register(self._semlock.name)
+        resource_tracker.register(self._semlock.name, "semlock")
         util.Finalize(self, SemLock._cleanup, (self._semlock.name,),
                       exitpriority=0)
 
     @staticmethod
     def _cleanup(name):
         sem_unlink(name)
-        semaphore_tracker.unregister(name)
+        resource_tracker.unregister(name, "semlock")
 
     def _make_methods(self):
         self.acquire = self._semlock.acquire

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -57,6 +57,7 @@ def _running_children_with_cmdline(p):
     all_children = _direct_children_with_cmdline(p)
     workers = [(c, cmdline) for c, cmdline in all_children
                if (u'semaphore_tracker' not in cmdline and
+                   u'resource_tracker' not in cmdline and
                    u'multiprocessing.forkserver' not in cmdline)]
 
     forkservers = [c for c, cmdline in all_children

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -116,7 +116,7 @@ class ExecutorShutdownTest:
             e.submit(id, ExitAtPickle())
 
     def test_interpreter_shutdown(self):
-        # Free ressources to avoid random timeout in CI
+        # Free resources to avoid random timeout in CI
         self.executor.shutdown(wait=True, kill_workers=True)
 
         tempdir = tempfile.mkdtemp(prefix='loky_')

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -200,19 +200,19 @@ class TestResourceTracker:
                 assert len(all_warn) == 0
 
     @pytest.mark.skipif(sys.platform == "win32",
-                        "Limited signal support on Windows")
+                        reason="Limited signal support on Windows")
     def test_resource_tracker_sigint(self):
         # Catchable signal (ignored by resource tracker)
         self.check_resource_tracker_death(signal.SIGINT, False)
 
     @pytest.mark.skipif(sys.platform == "win32",
-                        "Limited signal support on Windows")
+                        reason="Limited signal support on Windows")
     def test_resource_tracker_sigterm(self):
         # Catchable signal (ignored by resource tracker)
         self.check_resource_tracker_death(signal.SIGTERM, False)
 
     @pytest.mark.skipif(sys.platform == "win32",
-                        "Limited signal support on Windows")
+                        reason="Limited signal support on Windows")
     @pytest.mark.skipif(sys.version_info[0] < 3,
                         reason="warnings.catch_warnings limitation")
     def test_resource_tracker_sigkill(self):

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -24,8 +24,6 @@ def get_rtracker_pid():
     resource_tracker.ensure_running()
     return resource_tracker._resource_tracker._pid
 
-@pytest.mark.skipif(sys.platform == "win32",
-                    reason="no resource_tracker on windows")
 class TestResourceTracker:
     def test_child_retrieves_resource_tracker(self):
         parent_rtracker_pid = get_rtracker_pid()
@@ -87,8 +85,8 @@ class TestResourceTracker:
         #
         # Check that killing process does not leak named resources
         #
-        if sys.platform == "win32":
-            # no resource_tracker on windows
+        if (sys.platform == "win32") and rtype == "semlock":
+            # no semlock on windows
             return
 
         import subprocess
@@ -201,14 +199,20 @@ class TestResourceTracker:
             else:
                 assert len(all_warn) == 0
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        "Limited signal support on Windows")
     def test_resource_tracker_sigint(self):
         # Catchable signal (ignored by resource tracker)
         self.check_resource_tracker_death(signal.SIGINT, False)
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        "Limited signal support on Windows")
     def test_resource_tracker_sigterm(self):
         # Catchable signal (ignored by resource tracker)
         self.check_resource_tracker_death(signal.SIGTERM, False)
 
+    @pytest.mark.skipif(sys.platform == "win32",
+                        "Limited signal support on Windows")
     @pytest.mark.skipif(sys.version_info[0] < 3,
                         reason="warnings.catch_warnings limitation")
     def test_resource_tracker_sigkill(self):

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -169,7 +169,7 @@ class TestResourceTracker:
             warnings.simplefilter("ignore")
             _resource_tracker.ensure_running()
             # in python < 3.3 , the race condition described in bpo-33613 still
-            # exists, as this fixe requires signal.pthread_sigmask
+            # exists, as this fix requires signal.pthread_sigmask
             time.sleep(1.0)
         pid = _resource_tracker._pid
 

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -131,8 +131,7 @@ class TestResourceTracker:
             import msvcrt
             p = subprocess.Popen([sys.executable, '-E', '-c',
                                   cmd.format(w=msvcrt.get_osfhandle(w))],
-                                 stderr=subprocess.PIPE,
-                                 close_fds=True)
+                                 stderr=subprocess.PIPE)
 
         else:
             p = subprocess.Popen([sys.executable, '-E', '-c', cmd.format(w=w)],

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -13,16 +13,17 @@ import weakref
 
 from loky import ProcessPoolExecutor
 import loky.backend.resource_tracker as resource_tracker
-from loky.backend.semlock import sem_unlink
 from loky.backend.context import get_context
 
 
 def _resource_unlink(name, rtype):
     resource_tracker._CLEANUP_FUNCS[rtype](name)
 
+
 def get_rtracker_pid():
     resource_tracker.ensure_running()
     return resource_tracker._resource_tracker._pid
+
 
 class TestResourceTracker:
     def test_child_retrieves_resource_tracker(self):

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -51,7 +51,7 @@ class TestResourceTracker:
         # We don't need to create the semaphore as registering / unregistering
         # operations simply add / remove entries from a cache, but do not
         # manipulate the actual semaphores.
-        semaphore_tracker.register(semlock_name)
+        resource_tracker.register(semlock_name, "semlock")
 
         def unregister(name, rtype):
             # resource_tracker.unregister is actually a bound method of the

--- a/tests/test_resource_tracker.py
+++ b/tests/test_resource_tracker.py
@@ -24,6 +24,8 @@ def get_rtracker_pid():
     resource_tracker.ensure_running()
     return resource_tracker._resource_tracker._pid
 
+@pytest.mark.skipif(sys.version_info[0] < 3,
+                    reason="python2.7 not supported anymore")
 class TestResourceTracker:
     def test_child_retrieves_resource_tracker(self):
         parent_rtracker_pid = get_rtracker_pid()

--- a/tests/test_semaphore_tracker.py
+++ b/tests/test_semaphore_tracker.py
@@ -25,9 +25,14 @@ def get_sem_tracker_pid():
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="no semaphore_tracker on windows")
 class TestSemaphoreTracker:
+
     def test_child_retrieves_semaphore_tracker(self):
         parent_sem_tracker_pid = get_sem_tracker_pid()
-        executor = ProcessPoolExecutor(max_workers=1)
+        executor = ProcessPoolExecutor(max_workers=2)
+        child_sem_tracker_pid = executor.submit(get_sem_tracker_pid).result()
+
+        # First simple pid retrieval check (see #200)
+        assert child_sem_tracker_pid == parent_sem_tracker_pid
 
         # Register a semaphore in the parent process, and un-register it in the
         # child process. If the two processes do not share the same
@@ -61,12 +66,6 @@ class TestSemaphoreTracker:
         e.shutdown()
         '''
         try:
-            child_sem_tracker_pid = executor.submit(
-                get_sem_tracker_pid).result()
-
-            # First simple pid retrieval check (see #200)
-            assert child_sem_tracker_pid == parent_sem_tracker_pid
-
             p = subprocess.Popen(
                 [sys.executable, '-E', '-c', cmd.format(semlock_name)],
                 stderr=subprocess.PIPE)
@@ -80,7 +79,6 @@ class TestSemaphoreTracker:
 
         finally:
             executor.shutdown()
-
 
     # The following four tests are inspired from cpython _test_multiprocessing
     def test_semaphore_tracker(self):


### PR DESCRIPTION
This PR aims at extending the current `SemaphoreTracker` to make it able to track more generic named resources, such as folders, and potentially `memmap` and shared memory.

Many small changes in files because of the name refactoring. The main change is the registering/unregistering API extension: when one wants to track a new resource, one must (along with the resource name), specify the resource type. This is necessary for the `RessourceTracker` to know which cleanup function to use for each resource before shutdown.

Base branch: https://github.com/tomMoral/loky/pull/202