### PR TITLE
CI skip file descriptor test for PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ matrix:
       env: TOXENV="py37" RUN_MEMORY="true"
     - python: "3.6"
       env: TOXENV="py36" JOBLIB_TESTS="true"
-  allow_failures:
-    # Running the pypy test suite is temporarily allowed to fail because of
-    # some regressions introduced in recent pytest releases (see
-    # https://github.com/pytest-dev/pytest/issues/5317)
-    - python: "pypy3.5"
-      env: TOXENV="pypy3" LOKY_MAX_CPU_COUNT="2"
 
 before_install:
   - |

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -5,6 +5,7 @@ import psutil
 import pytest
 import signal
 import pickle
+import platform
 import socket
 import multiprocessing as mp
 from tempfile import mkstemp
@@ -514,6 +515,11 @@ class TestLokyBackend:
 
         return named_sem
 
+    @pytest.mark.skipif(
+        platform.python_implementation() == "PyPy" and
+        sys.version_info[:3] <= (3, 5, 3),
+        reason="early PyPy versions leak a file descriptor, see "
+               "https://bitbucket.org/pypy/pypy/issues/3021")
     def test_sync_object_handling(self):
         """Check the correct handling of semaphores and pipes with loky
 


### PR DESCRIPTION
Follow up on #209 
The recent CI failures were caused by a leaked file descriptor in `PyPy`: [ioopen-directory-leaks-a-file-descriptor](https://bitbucket.org/pypy/pypy/issues/3021/ioopen-directory-leaks-a-file-descriptor).
Now that we identified the issue, I think we should simply skip the failing test, and not allow the test suite run to fail.