### PR TITLE
FIX skip waitpid on Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### 2.5.1dev0 - In development
 
 - Fix a bug of the ``resource_tracker``  that could create unlimited freeze on
-    Windows (#212)
+  Windows (#212)
 
 
 ### 2.5.0 - 2019-06-07

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
-### 2.5.0dev0 - In development
+### 2.5.1dev0 - In development
+
+- Fix a bug of the ``resource_tracker``  that could create unlimited freeze on
+    Windows (#212)
 
 
 ### 2.5.0 - 2019-06-07

--- a/loky/backend/resource_tracker.py
+++ b/loky/backend/resource_tracker.py
@@ -85,13 +85,16 @@ class ResourceTracker(object):
                     return
                 # => dead, launch it again
                 os.close(self._fd)
-                try:
-                    # Clean-up to avoid dangling processes.
-                    os.waitpid(self._pid, 0)
-                except OSError:
-                    # The process was terminated or is a child from an ancestor
-                    # of the current process.
-                    pass
+                if os.name == "posix":
+                    try:
+                        # At this point, the resource_tracker process has been
+                        # killed or crashed. Let's remove the process entry
+                        # from the process table to avoid zombie processes.
+                        os.waitpid(self._pid, 0)
+                    except OSError:
+                        # The process was terminated or is a child from an
+                        # ancestor of the current process.
+                        pass
                 self._fd = None
                 self._pid = None
 


### PR DESCRIPTION
Fixes the failures that appeared in joblib/joblib#888 while vendoring the new `cloudpickle` and  `loky` inside `joblib`.  