### PR TITLE
[WIP] Python3-only reusable thread executor

### DIFF
--- a/loky/__init__.py
+++ b/loky/__init__.py
@@ -13,13 +13,16 @@ from .backend.reduction import set_loky_pickler
 from .reusable_executor import get_reusable_executor
 from .cloudpickle_wrapper import wrap_non_picklable_objects
 from .process_executor import BrokenProcessPool, ProcessPoolExecutor
+from .reusable_thread_executor import (ThreadPoolExecutor,
+                                       get_reusable_thread_executor)
 
 
-__all__ = ["get_reusable_executor", "cpu_count", "wait", "as_completed",
-           "Future", "Executor", "ProcessPoolExecutor",
-           "BrokenProcessPool", "CancelledError", "TimeoutError",
-           "FIRST_COMPLETED", "FIRST_EXCEPTION", "ALL_COMPLETED",
-           "wrap_non_picklable_objects", "set_loky_pickler"]
+__all__ = ["get_reusable_executor", "get_reusable_thread_executor",
+           "cpu_count", "wait", "as_completed", "Future", "Executor",
+           "ProcessPoolExecutor", "ThreadPoolExecutor" "BrokenProcessPool",
+           "CancelledError", "TimeoutError", "FIRST_COMPLETED",
+           "FIRST_EXCEPTION", "ALL_COMPLETED", "wrap_non_picklable_objects",
+           "set_loky_pickler"]
 
 
 __version__ = '2.5.1'

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -103,7 +103,7 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
                           .format(max_workers))
             executor_id = _get_next_executor_id()
             _executor_kwargs = kwargs
-            _executor = executor = _ReusablePoolExecutor(
+            _executor = executor = _ReusableProcessPoolExecutor(
                 _executor_lock, max_workers=max_workers,
                 executor_id=executor_id, **kwargs)
         else:
@@ -134,11 +134,11 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     return executor
 
 
-class _ReusablePoolExecutor(ProcessPoolExecutor):
+class _ReusableProcessPoolExecutor(ProcessPoolExecutor):
     def __init__(self, submit_resize_lock, max_workers=None, context=None,
                  timeout=None, executor_id=0, job_reducers=None,
                  result_reducers=None, initializer=None, initargs=()):
-        super(_ReusablePoolExecutor, self).__init__(
+        super(_ReusableProcessPoolExecutor, self).__init__(
             max_workers=max_workers, context=context, timeout=timeout,
             job_reducers=job_reducers, result_reducers=result_reducers,
             initializer=initializer, initargs=initargs)
@@ -147,7 +147,7 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
 
     def submit(self, fn, *args, **kwargs):
         with self._submit_resize_lock:
-            return super(_ReusablePoolExecutor, self).submit(
+            return super(_ReusableProcessPoolExecutor, self).submit(
                 fn, *args, **kwargs)
 
     def _resize(self, max_workers):
@@ -201,5 +201,5 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
         # As this executor can be resized, use a large queue size to avoid
         # underestimating capacity and introducing overhead
         queue_size = 2 * cpu_count() + EXTRA_QUEUED_CALLS
-        super(_ReusablePoolExecutor, self)._setup_queues(
+        super(_ReusableProcessPoolExecutor, self)._setup_queues(
             job_reducers, result_reducers, queue_size=queue_size)

--- a/loky/reusable_thread_executor.py
+++ b/loky/reusable_thread_executor.py
@@ -1,0 +1,200 @@
+import multiprocessing as mp
+import threading
+import weakref
+from concurrent.futures import _base, thread
+from concurrent.futures.thread import ThreadPoolExecutor
+
+_next_thread_executor_id = 0
+_thread_executor_kwargs = None
+_thread_executor = None
+
+
+def _get_next_thread_executor_id():
+    """Ensure that each successive executor instance has a unique monotonic id.
+
+    The purpose of this monotonic id is to help debug and test automated
+    instance creation.
+    """
+    global _next_thread_executor_id
+    thread_executor_id = _next_thread_executor_id
+    _next_thread_executor_id += 1
+    return thread_executor_id
+
+
+def _worker(executor_reference, work_queue, initializer, initargs):
+    if initializer is not None:
+        try:
+            initializer(*initargs)
+        except BaseException:
+            _base.LOGGER.critical("Exception in initializer:", exc_info=True)
+            executor = executor_reference()
+            if executor is not None:
+                executor._initializer_failed()
+            return
+    try:
+        while True:
+            work_item = work_queue.get(block=True)
+            if work_item is not None:
+                work_item.run()
+                # Delete references to object. See issue16284
+                del work_item
+                continue
+            executor = executor_reference()
+            # Exit if:
+            #   - The interpreter is shutting down OR
+            #   - The executor that owns the worker has been collected OR
+            #   - The executor that owns the worker has been shutdown.
+            if thread._shutdown or executor is None or executor._shutdown:
+                # Flag the executor as shutting down as early as possible if it
+                # is not gc-ed yet.
+                if executor is not None:
+                    executor._shutdown = True
+                # Notice other workers
+                work_queue.put(None)
+                del executor
+                return
+            else:
+                # Leave the thread pool. This comes from a resize event.
+                return
+    except BaseException:
+        _base.LOGGER.critical("Exception in worker", exc_info=True)
+
+
+class _ReusableThreadPoolExecutor(ThreadPoolExecutor):
+    def __init__(
+        self,
+        max_workers=None,
+        executor_id=0,
+        thread_name_prefix="",
+        initializer=None,
+        initargs=(),
+    ):
+        super(_ReusableThreadPoolExecutor, self).__init__(
+            max_workers=max_workers, initializer=initializer, initargs=initargs
+        )
+        self.executor_id = executor_id
+
+    def _resize(self, max_workers):
+        if max_workers is None:
+            raise ValueError("Trying to resize with max_workers=None")
+        elif max_workers == self._max_workers:
+            return
+
+        nb_children_alive = sum(t.is_alive() for t in self._threads)
+
+        for _ in range(max_workers, nb_children_alive):
+            self._work_queue.put(None)
+
+        # The original ThreadPoolExecutor of concurrent.futures adds threads
+        # lazily during `executor.submit` calls. We stick to this behavior in
+        # the case where threads should be added to the pool (max_workers >
+        # nb_children_alive)
+        self._max_workers = max_workers
+
+    def _adjust_thread_count(self):
+        # When the executor gets lost, the weakref callback will wake up
+        # the worker threads.
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+
+        # TODO(bquinlan): Should avoid creating new threads if there are more
+        # idle threads than items in the work queue.
+        num_threads = len(self._threads)
+        if num_threads < self._max_workers:
+            thread_name = "%s_%d" % (
+                self._thread_name_prefix or self,
+                num_threads,
+            )
+            # use our custom _worker function as a target, that can kill
+            # where workers can die without shutting down the executor
+            t = threading.Thread(
+                name=thread_name,
+                target=_worker,
+                args=(
+                    weakref.ref(self, weakref_cb),
+                    self._work_queue,
+                    self._initializer,
+                    self._initargs,
+                ),
+            )
+            t.daemon = True
+            t.start()
+            self._threads.add(t)
+            thread._threads_queues[t] = self._work_queue
+
+
+def get_reusable_thread_executor(
+    max_workers=None, reuse="auto", initializer=None, initargs=()
+):
+    """Return the current _ReusableThreadPoolExectutor instance.
+
+    Start a new instance if it has not been started already or if the previous
+    instance was left in a broken state.
+
+    If the previous instance does not have the requested number of workers, the
+    executor is dynamically resized to adjust the number of workers prior to
+    returning.
+
+    Reusing a singleton instance spares the overhead of starting new worker
+    threads and re-executing initializer functions each time.
+
+    ``max_workers`` controls the maximum number of tasks that can be running in
+    parallel in worker threads. By default this is set to the number of
+    5 times the number of CPUs on the host.
+
+    When provided, the ``initializer`` is run first in newly created
+    threads with argument ``initargs``.
+    """
+    global _thread_executor, _thread_executor_kwargs
+    thread_executor = _thread_executor
+
+    if max_workers is None:
+        if reuse is True and thread_executor is not None:
+            max_workers = thread_executor._max_workers
+        else:
+            max_workers = (mp.cpu_count() or 1) * 5
+    elif max_workers <= 0:
+        raise ValueError(
+            "max_workers must be greater than 0, got {}.".format(max_workers)
+        )
+
+    kwargs = dict(initializer=initializer, initargs=initargs)
+    if thread_executor is None:
+        mp.util.debug(
+            "Create a thread_executor with max_workers={}.".format(max_workers)
+        )
+        executor_id = _get_next_thread_executor_id()
+        _thread_executor_kwargs = kwargs
+        _thread_executor = thread_executor = _ReusableThreadPoolExecutor(
+            max_workers=max_workers, executor_id=executor_id, **kwargs
+        )
+    else:
+        if reuse == "auto":
+            reuse = kwargs == _thread_executor_kwargs
+        if thread_executor._broken or thread_executor._shutdown or not reuse:
+            if thread_executor._broken:
+                reason = "broken"
+            elif thread_executor._shutdown:
+                reason = "shutdown"
+            else:
+                reason = "arguments have changed"
+            mp.util.debug(
+                "Creating a new thread_executor with max_workers={} as the "
+                "previous instance cannot be reused ({}).".format(
+                    max_workers, reason
+                )
+            )
+            thread_executor.shutdown(wait=True)
+            _thread_executor = thread_executor = _thread_executor_kwargs = None
+            # Recursive call to build a new instance
+            return get_reusable_thread_executor(
+                max_workers=max_workers, **kwargs
+            )
+        else:
+            mp.util.debug(
+                "Reusing existing thread_executor with "
+                "max_workers={}.".format(thread_executor._max_workers)
+            )
+            thread_executor._resize(max_workers)
+
+    return thread_executor

--- a/loky/reusable_thread_executor.py
+++ b/loky/reusable_thread_executor.py
@@ -70,7 +70,8 @@ class _ReusableThreadPoolExecutor(ThreadPoolExecutor):
         initargs=(),
     ):
         super(_ReusableThreadPoolExecutor, self).__init__(
-            max_workers=max_workers, initializer=initializer, initargs=initargs
+            max_workers=max_workers, initializer=initializer,
+            initargs=initargs, thread_name_prefix=thread_name_prefix
         )
         self.executor_id = executor_id
 

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -119,7 +119,7 @@ def _check_executor_started(executor):
         raise RuntimeError("Executor took too long to run basic task.")
 
 
-class ExecutorMixin:
+class ProcessExecutorMixin:
     worker_count = 5
 
     @classmethod

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -125,8 +125,6 @@ def _check_executor_started(executor):
 
 
 class ExecutorMixin:
-    worker_count = 5
-
     def setup_method(self):
         try:
             if hasattr(self, "context"):
@@ -151,6 +149,7 @@ class ExecutorMixin:
 
 
 class ProcessExecutorMixin(ExecutorMixin):
+    worker_count = 5
     @pytest.fixture(autouse=True)
     def setup_method(self):
         global _test_event
@@ -213,6 +212,7 @@ class ProcessExecutorMixin(ExecutorMixin):
 
 
 class ThreadExecutorMixin(ExecutorMixin):
+    worker_count = None
     executor_type = _ReusableThreadPoolExecutor
 
     @pytest.fixture(autouse=True)

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -217,6 +217,8 @@ class ThreadExecutorMixin(ExecutorMixin):
 
     @pytest.fixture(autouse=True)
     def setup_method(self):
+        global _test_event
+        assert _test_event is not None
         super(ThreadExecutorMixin, self).setup_method()
 
     def teardown_method(self, method):
@@ -235,6 +237,12 @@ class ThreadExecutorMixin(ExecutorMixin):
             dt = time.time() - t_start
             assert dt < 10, "Executor took too long to shutdown"
 
+    @classmethod
+    def setup_class(cls):
+        print("setup class with threading context")
+        global _test_event
+        if _test_event is None:
+            _test_event = threading.Event()
 
 class ReusableExecutorMixin:
 

--- a/tests/_executor_mixin.py
+++ b/tests/_executor_mixin.py
@@ -215,6 +215,10 @@ class ProcessExecutorMixin(ExecutorMixin):
 class ThreadExecutorMixin(ExecutorMixin):
     executor_type = _ReusableThreadPoolExecutor
 
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        super(ThreadExecutorMixin, self).setup_method()
+
     def teardown_method(self, method):
         # Make sure executor is not broken if it should not be
         executor = getattr(self, 'executor', None)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -499,8 +499,6 @@ class AsCompletedTests:
 
 
 class ExecutorTest:
-    # Executor.shutdown() and context manager usage is tested by
-    # ExecutorShutdownTest.
     def test_submit(self):
         future = self.executor.submit(pow, 2, 8)
         assert 256 == future.result()
@@ -528,13 +526,6 @@ class ExecutorTest:
 
         assert [None, None] == results
 
-    def test_shutdown_race_issue12456(self):
-        # Issue #12456: race condition at shutdown where trying to post a
-        # sentinel in the call queue blocks (the queue is full while processes
-        # have exited).
-        self.executor.map(str, [2] * (self.worker_count + 1))
-        self.executor.shutdown()
-
     def test_no_stale_references(self):
         # Issue #16284: check that the executors don't unnecessarily hang onto
         # references.
@@ -553,6 +544,17 @@ class ExecutorTest:
             if collected:
                 return
         assert collected, "Stale reference not collected within timeout."
+
+
+class ProcessExecutorTest(ExecutorTest):
+    # Executor.shutdown() and context manager usage is tested by
+    # ExecutorShutdownTest.
+    def test_shutdown_race_issue12456(self):
+        # Issue #12456: race condition at shutdown where trying to post a
+        # sentinel in the call queue blocks (the queue is full while processes
+        # have exited).
+        self.executor.map(str, [2] * (self.worker_count + 1))
+        self.executor.shutdown()
 
     def test_max_workers_negative(self):
         for number in (0, -1):

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -198,7 +198,7 @@ class TestsThreadExecutorShutdown(ExecutorShutdownTest,
         pass
 
     def test_context_manager_shutdown(self):
-        with futures.ThreadPoolExecutor(max_workers=5) as e:
+        with self.executor as e:
             executor = e
             assert list(
                 e.map(abs, range(-5, 5))) == [5, 4, 3, 2, 1, 0, 1, 2, 3, 4]
@@ -207,16 +207,15 @@ class TestsThreadExecutorShutdown(ExecutorShutdownTest,
             t.join()
 
     def test_del_shutdown(self):
-        executor = futures.ThreadPoolExecutor(max_workers=5)
-        executor.map(abs, range(-5, 5))
-        threads = executor._threads
-        del executor
+        self.executor.map(abs, range(-5, 5))
+        threads = self.executor._threads
+        del self.executor
 
         for t in threads:
             t.join()
 
     def test_thread_names_assigned(self):
-        executor = futures.ThreadPoolExecutor(
+        executor = self.executor_type(
             max_workers=5, thread_name_prefix='SpecialPool')
         executor.map(abs, range(-5, 5))
         threads = executor._threads
@@ -228,7 +227,7 @@ class TestsThreadExecutorShutdown(ExecutorShutdownTest,
 
 
     def test_thread_names_default(self):
-        executor = futures.ThreadPoolExecutor(max_workers=5)
+        executor = self.executor_type(max_workers=5)
         executor.map(abs, range(-5, 5))
         threads = executor._threads
         del executor
@@ -241,7 +240,7 @@ class TestsThreadExecutorShutdown(ExecutorShutdownTest,
 
 
     def test_thread_terminate(self):
-        executor = futures.ThreadPoolExecutor(max_workers=5)
+        executor = self.executor_type(max_workers=5)
         def acquire_lock(lock):
             lock.acquire()
 

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -486,6 +486,8 @@ class WaitTests:
 class ThreadWaitTest:
     def test_pending_calls_race(self):
         pass
+
+
 class AsCompletedTests:
     # TODO(brian@sweetapp.com): Should have a test with a non-zero timeout.
     def test_no_timeout(self):

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -192,70 +192,6 @@ class ExecutorShutdownTest:
             shutil.rmtree(tempdir)
 
 
-class TestsThreadExecutorShutdown(ExecutorShutdownTest,
-                                  _executor_mixin.ThreadExecutorMixin):
-    def prime_executor(self):
-        pass
-
-    def test_context_manager_shutdown(self):
-        with self.executor as e:
-            executor = e
-            assert list(
-                e.map(abs, range(-5, 5))) == [5, 4, 3, 2, 1, 0, 1, 2, 3, 4]
-
-        for t in executor._threads:
-            t.join()
-
-    def test_del_shutdown(self):
-        self.executor.map(abs, range(-5, 5))
-        threads = self.executor._threads
-        del self.executor
-
-        for t in threads:
-            t.join()
-
-    def test_thread_names_assigned(self):
-        executor = self.executor_type(
-            max_workers=5, thread_name_prefix='SpecialPool')
-        executor.map(abs, range(-5, 5))
-        threads = executor._threads
-        del executor
-
-        for t in threads:
-            assert re.match(r'^SpecialPool_[0-4]$', t.name)
-            t.join()
-
-
-    def test_thread_names_default(self):
-        executor = self.executor_type(max_workers=5)
-        executor.map(abs, range(-5, 5))
-        threads = executor._threads
-        del executor
-
-        for t in threads:
-            # Ensure that our default name is reasonably sane and unique when
-            # no thread_name_prefix was supplied.
-            assert re.match(r'ThreadPoolExecutor-\d+_[0-4]$', t.name)
-            t.join()
-
-
-    def test_thread_terminate(self):
-        executor = self.executor_type(max_workers=5)
-        def acquire_lock(lock):
-            lock.acquire()
-
-        sem = threading.Semaphore(0)
-        for i in range(3):
-            executor.submit(acquire_lock, sem)
-        assert len(executor._threads) == 3
-        for i in range(3):
-            sem.release()
-        executor.shutdown()
-        for t in executor._threads:
-            t.join()
-
-
-
 class ProcessExecutorShutdownTest:
 
     def test_shutdown_with_pickle_error(self):
@@ -551,26 +487,6 @@ class WaitTests:
         _executor_mixin._test_event.clear()
 
 
-class TestsThreadWait(WaitTests, _executor_mixin.ThreadExecutorMixin):
-    def test_pending_calls_race(self):
-        # Issue #14406: multi-threaded race condition when waiting on all
-        # futures.
-        event = threading.Event()
-
-        def future_func():
-            event.wait()
-        oldswitchinterval = sys.getswitchinterval()
-        sys.setswitchinterval(1e-6)
-        try:
-            fs = {self.executor.submit(future_func) for i in range(100)}
-            event.set()
-            futures.wait(fs, return_when=futures.ALL_COMPLETED)
-        finally:
-            sys.setswitchinterval(oldswitchinterval)
-
-
-
-
 class AsCompletedTests:
     # TODO(brian@sweetapp.com): Should have a test with a non-zero timeout.
     def test_no_timeout(self):
@@ -606,10 +522,6 @@ class AsCompletedTests:
         completed = [f for f in futures.as_completed([future1, future1])]
         assert len(completed) == 1
 
-
-class TestsThreadAsCompleted(AsCompletedTests,
-                             _executor_mixin.ThreadExecutorMixin):
-    pass
 
 class ExecutorTest:
     def test_submit(self):
@@ -1009,47 +921,3 @@ class ProcessExecutorTest(ExecutorTest):
             self.executor.submit(pow, 2, 8)
 
 
-class TestsThreadExecutor(ExecutorTest, _executor_mixin.ThreadExecutorMixin):
-    def test_map_submits_without_iteration(self):
-        """Tests verifying issue 11777."""
-        finished = []
-
-        def record_finished(n):
-            finished.append(n)
-
-        self.executor.map(record_finished, range(10))
-        self.executor.shutdown(wait=True)
-        assert Counter(list(finished)) == Counter(list(range(10)))
-
-    def test_default_workers(self):
-        executor = self.executor_type()
-        if sys.version_info[:2] > (3, 8):
-            expected = min(32, (os.cpu_count() or 1) + 4)
-        else:
-            expected = min(32, (os.cpu_count() or 1) * 5)
-        assert executor._max_workers == expected
-
-    def test_saturation(self):
-        executor = self.executor_type(4)
-
-        def acquire_lock(lock):
-            lock.acquire()
-
-        sem = threading.Semaphore(0)
-        for i in range(15 * executor._max_workers):
-            executor.submit(acquire_lock, sem)
-        assert len(executor._threads) == executor._max_workers
-        for i in range(15 * executor._max_workers):
-            sem.release()
-        executor.shutdown(wait=True)
-
-    @pytest.mark.skipif(
-        sys.version_info[:2] < (3, 8),
-        reason="idle threads re-usage was introduced in Python3.8")
-    def test_idle_thread_reuse(self):
-        executor = self.executor_type()
-        executor.submit(mul, 21, 2).result()
-        executor.submit(mul, 6, 7).result()
-        executor.submit(mul, 3, 14).result()
-        assert len(executor._threads) == 1
-        executor.shutdown(wait=True)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -402,6 +402,7 @@ class WaitTests:
         return True
 
     def test_first_exception(self):
+        # XXX: this one slightly differs from the cpython analogous test
         future1 = self.executor.submit(mul, 2, 21)
         future2 = self.executor.submit(self.wait_and_raise, 1.5)
         future3 = self.executor.submit(time.sleep, 3)
@@ -456,6 +457,7 @@ class WaitTests:
         assert set() == pending
 
     def test_timeout(self):
+        # XXX: this one slightly differs from the cpython analogous test
         # Make sure the executor has already started to avoid timeout happening
         # before future1 returns
         assert self.executor.submit(id_sleep, 42).result() == 42

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -607,6 +607,10 @@ class AsCompletedTests:
         assert len(completed) == 1
 
 
+class TestsThreadAsCompleted(AsCompletedTests,
+                             _executor_mixin.ThreadExecutorMixin):
+    pass
+
 class ExecutorTest:
     def test_submit(self):
         future = self.executor.submit(pow, 2, 8)

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -480,6 +480,9 @@ class WaitTests:
         _executor_mixin._test_event.clear()
 
 
+class ThreadWaitTest:
+    def test_pending_calls_race(self):
+        pass
 class AsCompletedTests:
     # TODO(brian@sweetapp.com): Should have a test with a non-zero timeout.
     def test_no_timeout(self):

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -199,7 +199,7 @@ class ThreadExecutorShutdownTest:
         del executor
 
         for t in threads:
-            assert re.match(t.name, r'^SpecialPool_[0-4]$') is not None
+            assert re.match(r'^SpecialPool_[0-4]$', t.name)
             t.join()
 
 
@@ -212,7 +212,7 @@ class ThreadExecutorShutdownTest:
         for t in threads:
             # Ensure that our default name is reasonably sane and unique when
             # no thread_name_prefix was supplied.
-            self.assertRegex(t.name, r'ThreadPoolExecutor-\d+_[0-4]$')
+            assert re.match(r'ThreadPoolExecutor-\d+_[0-4]$', t.name)
             t.join()
 
 

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -33,10 +33,10 @@ if (sys.version_info[:2] > (3, 3)
                                                 AsCompletedTests):
         pass
 
-    from ._test_process_executor import ExecutorTest
+    from ._test_process_executor import ProcessExecutorTest
 
     class TestsProcessPoolForkserverExecutor(ProcessPoolForkserverMixin,
-                                             ExecutorTest):
+                                             ProcessExecutorTest):
         pass
 
-    from ._test_process_executor import ExecutorTest
+    from ._test_process_executor import ProcessExecutorTest

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -14,10 +14,10 @@ if (sys.version_info[:2] > (3, 3)
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('forkserver')
 
-    from ._test_process_executor import ExecutorShutdownTest
+    from ._test_process_executor import ProcessExecutorShutdownTest
 
     class TestsProcessPoolForkserverShutdown(ProcessPoolForkserverMixin,
-                                             ExecutorShutdownTest):
+                                             ProcessExecutorShutdownTest):
         def _prime_executor(self):
             pass
 

--- a/tests/test_process_executor_forkserver.py
+++ b/tests/test_process_executor_forkserver.py
@@ -2,7 +2,7 @@ import sys
 
 from loky import process_executor
 from loky.backend import get_context
-from ._executor_mixin import ExecutorMixin
+from ._executor_mixin import ProcessExecutorMixin
 
 
 if (sys.version_info[:2] > (3, 3)
@@ -10,7 +10,7 @@ if (sys.version_info[:2] > (3, 3)
         and not hasattr(sys, "pypy_version_info")):
     # XXX: the forkserver backend is broken with pypy3.
 
-    class ProcessPoolForkserverMixin(ExecutorMixin):
+    class ProcessPoolForkserverMixin(ProcessExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('forkserver')
 

--- a/tests/test_process_executor_loky.py
+++ b/tests/test_process_executor_loky.py
@@ -5,7 +5,7 @@ from ._executor_mixin import ExecutorMixin
 from ._test_process_executor import WaitTests
 from ._test_process_executor import ProcessExecutorTest
 from ._test_process_executor import AsCompletedTests
-from ._test_process_executor import ExecutorShutdownTest
+from ._test_process_executor import ProcessExecutorShutdownTest
 
 
 class ProcessPoolLokyMixin(ExecutorMixin):
@@ -15,7 +15,7 @@ class ProcessPoolLokyMixin(ExecutorMixin):
 
 
 class TestsProcessPoolLokyShutdown(ProcessPoolLokyMixin,
-                                   ExecutorShutdownTest):
+                                   ProcessExecutorShutdownTest):
     def _prime_executor(self):
         pass
 

--- a/tests/test_process_executor_loky.py
+++ b/tests/test_process_executor_loky.py
@@ -3,7 +3,7 @@ from loky.backend import get_context
 from ._executor_mixin import ExecutorMixin
 
 from ._test_process_executor import WaitTests
-from ._test_process_executor import ExecutorTest
+from ._test_process_executor import ProcessExecutorTest
 from ._test_process_executor import AsCompletedTests
 from ._test_process_executor import ExecutorShutdownTest
 
@@ -31,5 +31,5 @@ class TestsProcessPoolLokyAsCompleted(ProcessPoolLokyMixin,
 
 
 class TestsProcessPoolLokyExecutor(ProcessPoolLokyMixin,
-                                   ExecutorTest):
+                                   ProcessExecutorTest):
     pass

--- a/tests/test_process_executor_loky.py
+++ b/tests/test_process_executor_loky.py
@@ -1,6 +1,6 @@
 from loky import process_executor
 from loky.backend import get_context
-from ._executor_mixin import ExecutorMixin
+from ._executor_mixin import ProcessExecutorMixin
 
 from ._test_process_executor import WaitTests
 from ._test_process_executor import ProcessExecutorTest
@@ -8,7 +8,7 @@ from ._test_process_executor import AsCompletedTests
 from ._test_process_executor import ProcessExecutorShutdownTest
 
 
-class ProcessPoolLokyMixin(ExecutorMixin):
+class ProcessPoolLokyMixin(ProcessExecutorMixin):
     # Makes sure that the context is defined
     executor_type = process_executor.ProcessPoolExecutor
     context = get_context("loky")

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -11,10 +11,10 @@ if (sys.version_info[:2] > (3, 3)
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('spawn')
 
-    from ._test_process_executor import ExecutorShutdownTest
+    from ._test_process_executor import ProcessExecutorShutdownTest
 
     class TestsProcessPoolSpawnShutdown(ProcessPoolSpawnMixin,
-                                        ExecutorShutdownTest):
+                                        ProcessExecutorShutdownTest):
         def _prime_executor(self):
             pass
 

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -2,12 +2,12 @@ import sys
 
 from loky import process_executor
 from loky.backend import get_context
-from ._executor_mixin import ExecutorMixin
+from ._executor_mixin import ProcessExecutorMixin
 
 
 if (sys.version_info[:2] > (3, 3)
         and not hasattr(sys, "pypy_version_info")):
-    class ProcessPoolSpawnMixin(ExecutorMixin):
+    class ProcessPoolSpawnMixin(ProcessExecutorMixin):
         executor_type = process_executor.ProcessPoolExecutor
         context = get_context('spawn')
 

--- a/tests/test_process_executor_spawn.py
+++ b/tests/test_process_executor_spawn.py
@@ -29,9 +29,10 @@ if (sys.version_info[:2] > (3, 3)
                                            AsCompletedTests):
         pass
 
-    from ._test_process_executor import ExecutorTest
+    from ._test_process_executor import ProcessExecutorTest
 
-    class TestsProcessPoolSpawnExecutor(ProcessPoolSpawnMixin, ExecutorTest):
+    class TestsProcessPoolSpawnExecutor(
+            ProcessPoolSpawnMixin, ProcessExecutorTest):
         pass
 
-    from ._test_process_executor import ExecutorTest
+    from ._test_process_executor import ProcessExecutorTest

--- a/tests/test_reusable_executor.py
+++ b/tests/test_reusable_executor.py
@@ -411,8 +411,8 @@ class TestExecutorDeadLock(ReusableExecutorMixin):
         executor.shutdown(wait=True)
 
 
-class TestTerminateExecutor(ReusableExecutorMixin):
-
+class TestTerminateProcessExecutor(ReusableExecutorMixin):
+    get_reusable_executor = staticmethod(get_reusable_executor)
     def test_shutdown_kill(self):
         """Test reusable_executor termination handling"""
         from itertools import repeat

--- a/tests/test_thread_executor.py
+++ b/tests/test_thread_executor.py
@@ -1,0 +1,167 @@
+import os
+import re
+import sys
+import threading
+from collections import Counter
+
+import pytest
+
+from . import _executor_mixin
+from ._test_process_executor import (
+    ExecutorTest,
+    mul,
+    WaitTests,
+    ExecutorShutdownTest,
+    AsCompletedTests
+)
+
+if sys.version_info[:2] < (3, 3):
+    import loky._base as futures
+else:
+    from concurrent import futures
+
+
+class TestsThreadExecutor(ExecutorTest, _executor_mixin.ThreadExecutorMixin):
+    def test_map_submits_without_iteration(self):
+        """Tests verifying issue 11777."""
+        finished = []
+
+        def record_finished(n):
+            finished.append(n)
+
+        self.executor.map(record_finished, range(10))
+        self.executor.shutdown(wait=True)
+        assert Counter(list(finished)) == Counter(list(range(10)))
+
+    def test_default_workers(self):
+        executor = self.executor_type()
+        if sys.version_info[:2] > (3, 8):
+            expected = min(32, (os.cpu_count() or 1) + 4)
+        else:
+            expected = min(32, (os.cpu_count() or 1) * 5)
+        assert executor._max_workers == expected
+
+    def test_saturation(self):
+        executor = self.executor_type(4)
+
+        def acquire_lock(lock):
+            lock.acquire()
+
+        sem = threading.Semaphore(0)
+        for i in range(15 * executor._max_workers):
+            executor.submit(acquire_lock, sem)
+        assert len(executor._threads) == executor._max_workers
+        for i in range(15 * executor._max_workers):
+            sem.release()
+        executor.shutdown(wait=True)
+
+    @pytest.mark.skipif(
+        sys.version_info[:2] < (3, 8),
+        reason="idle threads re-usage was introduced in Python3.8",
+    )
+    def test_idle_thread_reuse(self):
+        executor = self.executor_type()
+        executor.submit(mul, 21, 2).result()
+        executor.submit(mul, 6, 7).result()
+        executor.submit(mul, 3, 14).result()
+        assert len(executor._threads) == 1
+        executor.shutdown(wait=True)
+
+
+class TestsThreadWait(WaitTests, _executor_mixin.ThreadExecutorMixin):
+    def test_pending_calls_race(self):
+        # Issue #14406: multi-threaded race condition when waiting on all
+        # futures.
+        event = threading.Event()
+
+        def future_func():
+            event.wait()
+
+        oldswitchinterval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            fs = {self.executor.submit(future_func) for i in range(100)}
+            event.set()
+            futures.wait(fs, return_when=futures.ALL_COMPLETED)
+        finally:
+            sys.setswitchinterval(oldswitchinterval)
+
+
+class TestsThreadExecutorShutdown(
+    ExecutorShutdownTest, _executor_mixin.ThreadExecutorMixin
+):
+    def prime_executor(self):
+        pass
+
+    def test_context_manager_shutdown(self):
+        with self.executor as e:
+            executor = e
+            assert list(e.map(abs, range(-5, 5))) == [
+                5,
+                4,
+                3,
+                2,
+                1,
+                0,
+                1,
+                2,
+                3,
+                4,
+            ]
+
+        for t in executor._threads:
+            t.join()
+
+    def test_del_shutdown(self):
+        self.executor.map(abs, range(-5, 5))
+        threads = self.executor._threads
+        del self.executor
+
+        for t in threads:
+            t.join()
+
+    def test_thread_names_assigned(self):
+        executor = self.executor_type(
+            max_workers=5, thread_name_prefix="SpecialPool"
+        )
+        executor.map(abs, range(-5, 5))
+        threads = executor._threads
+        del executor
+
+        for t in threads:
+            assert re.match(r"^SpecialPool_[0-4]$", t.name)
+            t.join()
+
+    def test_thread_names_default(self):
+        executor = self.executor_type(max_workers=5)
+        executor.map(abs, range(-5, 5))
+        threads = executor._threads
+        del executor
+
+        for t in threads:
+            # Ensure that our default name is reasonably sane and unique when
+            # no thread_name_prefix was supplied.
+            assert re.match(r"ThreadPoolExecutor-\d+_[0-4]$", t.name)
+            t.join()
+
+    def test_thread_terminate(self):
+        executor = self.executor_type(max_workers=5)
+
+        def acquire_lock(lock):
+            lock.acquire()
+
+        sem = threading.Semaphore(0)
+        for i in range(3):
+            executor.submit(acquire_lock, sem)
+        assert len(executor._threads) == 3
+        for i in range(3):
+            sem.release()
+        executor.shutdown()
+        for t in executor._threads:
+            t.join()
+
+
+class TestsThreadAsCompleted(
+    AsCompletedTests, _executor_mixin.ThreadExecutorMixin
+):
+    pass


### PR DESCRIPTION
Supersedes #189.

This is a Python3-only implementation of a reusable `ThreadPoolExecutor`. Making this Python3-only limits the maintainability burden of `loky` by not making us backport `threading` utilities for `Python2`.

In particular, this PR implements a new `_ReusableThreadPoolExecutor` class. The appropriate tests from the `loky`  as well as the `concurrent.futures.ThreadPoolExecutor` test suite are ran against it.

As a result, most of the changes in this code are test-suite additions-refactoring:
- adding all cross-backend (processes/threads) tests into new base test classes, while separating all   process-specific tests (tests about serialization, deadlocks, process termination etc. ) into new `[Theme]ProcessExecutorTest` classes
- backporting some threading-specific tests from `concurrent.futures`

There is still a bunch of style/renaming to do, but the major part of the work is done.