### PR TITLE
Fix loky for windows + python3.7 inside venv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### 2.5.2 - 2019-09-09 - Bugfix release
+
+- Fix a bug making all loky workers crash on Windows for Python>3.7 when using
+  a virtual environment (#216).
+
+
 ### 2.5.1 - 2019-06-11 - Bugfix release
 
 - Fix a bug of the ``resource_tracker``  that could create unlimited freeze on

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,9 @@ matrix:
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
+  # not already installed. We use tox-venv and not tox because of a previous
+  # bug affecting loky inside a venv-created virtual environment for
+  # Python3.7+, reported initially in joblib/joblib#901.
   - ps: ./continuous_integration/appveyor/install.ps1
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "SET LOKY_MAX_DEPTH=3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,13 @@ environment:
   # Python versions sequentially.
   # We run it once per architecture (32 bit vs 64 bit).
   matrix:
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
+      PYTHON_ARCH_SUFFIX: ""
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       PYTHON_ARCH_SUFFIX: "-x64"
 matrix:
@@ -19,8 +24,6 @@ install:
   - ps: ./continuous_integration/appveyor/install.ps1
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "SET LOKY_MAX_DEPTH=3"
-  - python -m venv ../python_venv
-  - ../python_venv/Scripts/activate.bat
   - "pip install tox tox-venv"
 
 # Not a .NET project, we build in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - "SET LOKY_MAX_DEPTH=3"
   - python -m venv ../python_venv
   - ../python_venv/Scripts/activate.bat
-  - "pip install tox"
+  - "pip install tox tox-venv"
 
 # Not a .NET project, we build in the install step instead
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,11 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
       PYTHON_ARCH_SUFFIX: "-x64"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+      PYTHON_ARCH_SUFFIX: "-x64"
 matrix:
   fast_finish: true
 
@@ -24,6 +29,8 @@ install:
   - ps: ./continuous_integration/appveyor/install.ps1
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "SET LOKY_MAX_DEPTH=3"
+  - python -m venv ../python_venv
+  - ../python_venv/Scripts/activate.bat
   - "pip install tox"
 
 # Not a .NET project, we build in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,6 @@ environment:
   # Python versions sequentially.
   # We run it once per architecture (32 bit vs 64 bit).
   matrix:
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "32"
-      PYTHON_ARCH_SUFFIX: ""
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_ARCH: "64"
-      PYTHON_ARCH_SUFFIX: "-x64"
-
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"

--- a/continuous_integration/appveyor/runtests.ps1
+++ b/continuous_integration/appveyor/runtests.ps1
@@ -3,7 +3,7 @@
 # Authors: Thomas Moreau
 # License: 3-clause BSD
 
-$VERSION=(36, 27)
+$VERSION=(37, 36, 27)
 $TOX_CMD = "python ./continuous_integration/appveyor/tox"
 
 function TestPythonVersions () {

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -35,7 +35,8 @@ def _path_eq(p1, p2):
     return p1 == p2 or os.path.normcase(p1) == os.path.normcase(p2)
 
 
-WINENV = not _path_eq(sys.executable, sys._base_executable)
+WINENV = (hasattr(sys, "_base_executable")
+          and not _path_eq(sys.executable, sys._base_executable))
 
 #
 # We define a Popen class similar to the one from subprocess, but


### PR DESCRIPTION
Fixes the error reported in joblib/joblib#901, namely that joblib does not work from inside a virtual environment on windows for Python3.7+. This is due to a change in the python's virtualenv executables.