### PR TITLE
ENH pass env var to child

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 - Fix a bug making all loky workers crash on Windows for Python>3.7 when using
   a virtual environment (#216).
 
+- Copy the environment variables in the child process for ``LokyProcess``.
+  This allow setting env variables before loading any module. (#217)
+
 
 ### 2.5.1 - 2019-06-11 - Bugfix release
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@
 - Copy the environment variables in the child process for ``LokyProcess``. Also
   add a ``env`` argument in ``LokyProcess``, ``ProcessPoolExecutor`` and
   ``get_reusable_executor`` to over-write consistently some environment variable
-  in the child process. This allow setting env variables before loading any
-  module. This feature is unstable with Python2.7 on windows. (#217)
+  in the child process. This allows setting env variables before loading any
+  module. This feature is unreliable on Windows with Python 2.7. (#217)
 
 
 ### 2.5.1 - 2019-06-11 - Bugfix release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,11 @@
 - Fix a bug making all loky workers crash on Windows for Python>3.7 when using
   a virtual environment (#216).
 
-- Copy the environment variables in the child process for ``LokyProcess``.
-  This allow setting env variables before loading any module. (#217)
+- Copy the environment variables in the child process for ``LokyProcess``. Also
+  add a ``env`` argument in ``LokyProcess``, ``ProcessPoolExecutor`` and
+  ``get_reusable_executor`` to over-write consistently some environment variable
+  in the child process. This allow setting env variables before loading any
+  module. This feature is unstable with Python2.7 on windows. (#217)
 
 
 ### 2.5.1 - 2019-06-11 - Bugfix release

--- a/continuous_integration/appveyor/runtests.ps1
+++ b/continuous_integration/appveyor/runtests.ps1
@@ -12,7 +12,7 @@ function TestPythonVersions () {
         $env:TOXPYTHON = "C:\Python$ver$env:PYTHON_ARCH_SUFFIX\python.exe"
         Write-Host $env:TOXPYTHON
         # Skip memory test as the appveyor environment is too small for those.
-        $PYTEST_ARGS = "-vl --timeout=60 --maxfail=5 --skip-high-memory"
+        $PYTEST_ARGS = "-rvl --timeout=60 --maxfail=5 --skip-high-memory"
 
         # Launch the tox command for the correct python version. We use `iex`
         # to correctly pass PYTEST_ARGS, which are parsed as files otherwise.

--- a/continuous_integration/appveyor/runtests.ps1
+++ b/continuous_integration/appveyor/runtests.ps1
@@ -12,7 +12,7 @@ function TestPythonVersions () {
         $env:TOXPYTHON = "C:\Python$ver$env:PYTHON_ARCH_SUFFIX\python.exe"
         Write-Host $env:TOXPYTHON
         # Skip memory test as the appveyor environment is too small for those.
-        $PYTEST_ARGS = "-rvl --timeout=60 --maxfail=5 --skip-high-memory"
+        $PYTEST_ARGS = "-vl --timeout=60 --maxfail=5 --skip-high-memory -rx"
 
         # Launch the tox command for the correct python version. We use `iex`
         # to correctly pass PYTEST_ARGS, which are parsed as files otherwise.

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -33,10 +33,11 @@ def close_fds(keep_fds):  # pragma: no cover
             pass
 
 
-def fork_exec(cmd, keep_fds):
+def fork_exec(cmd, keep_fds, env={}):
 
     # copy the environment variables to set in the child process
     child_env = os.environ.copy()
+    child_env.update(env)
 
     pid = os.fork()
     if pid == 0:  # pragma: no cover

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -35,7 +35,7 @@ def close_fds(keep_fds):  # pragma: no cover
 
 def fork_exec(cmd, keep_fds):
 
-    # copy and set the environment variables in the child process
+    # copy the environment variables to set in the child process
     child_env = os.environ.copy()
 
     pid = os.fork()

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -33,14 +33,14 @@ def close_fds(keep_fds):  # pragma: no cover
             pass
 
 
-def fork_exec(cmd, keep_fds, env={}):
+def fork_exec(cmd, keep_fds):
 
-    new_env = os.environ.copy()
-    new_env.update(env)
+    # copy and set the environment variables in the child process
+    child_env = os.environ.copy()
 
     pid = os.fork()
     if pid == 0:  # pragma: no cover
         close_fds(keep_fds)
-        os.execve(sys.executable, cmd, new_env)
+        os.execve(sys.executable, cmd, child_env)
     else:
         return pid

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -33,7 +33,7 @@ def close_fds(keep_fds):  # pragma: no cover
             pass
 
 
-def fork_exec(cmd, keep_fds, env={}):
+def fork_exec(cmd, keep_fds, env=None):
 
     # copy the environment variables to set in the child process
     child_env = os.environ.copy()

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -36,6 +36,7 @@ def close_fds(keep_fds):  # pragma: no cover
 def fork_exec(cmd, keep_fds, env=None):
 
     # copy the environment variables to set in the child process
+    env = {} if env is None else env
     child_env = os.environ.copy()
     child_env.update(env)
 

--- a/loky/backend/fork_exec.py
+++ b/loky/backend/fork_exec.py
@@ -33,11 +33,14 @@ def close_fds(keep_fds):  # pragma: no cover
             pass
 
 
-def fork_exec(cmd, keep_fds):
+def fork_exec(cmd, keep_fds, env={}):
+
+    new_env = os.environ.copy()
+    new_env.update(env)
 
     pid = os.fork()
     if pid == 0:  # pragma: no cover
         close_fds(keep_fds)
-        os.execv(sys.executable, cmd)
+        os.execve(sys.executable, cmd, new_env)
     else:
         return pid

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -44,12 +44,12 @@ if sys.platform != "win32":
         method = 'loky'
         DupFd = _DupFd
 
-        def __init__(self, process_obj):
+        def __init__(self, process_obj, env={}):
             sys.stdout.flush()
             sys.stderr.flush()
             self.returncode = None
             self._fds = []
-            self._launch(process_obj)
+            self._launch(process_obj, env)
 
         if sys.version_info < (3, 4):
             @classmethod
@@ -119,7 +119,7 @@ if sys.platform != "win32":
                     if self.wait(timeout=0.1) is None:
                         raise
 
-        def _launch(self, process_obj):
+        def _launch(self, process_obj, env):
 
             tracker_fd = resource_tracker._resource_tracker.getfd()
 
@@ -150,7 +150,7 @@ if sys.platform != "win32":
                 reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
                 from .fork_exec import fork_exec
-                pid = fork_exec(cmd_python, self._fds)
+                pid = fork_exec(cmd_python, self._fds, env=env)
                 util.debug("launched python with pid {} and cmd:\n{}"
                            .format(pid, cmd_python))
                 self.sentinel = parent_r

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -68,7 +68,7 @@ if sys.platform != "win32":
                 while True:
                     try:
                         pid, sts = os.waitpid(self.pid, flag)
-                    except OSError as e:
+                    except OSError:
                         # Child process not yet created. See #1731717
                         # e.errno == errno.ECHILD == 10
                         return None
@@ -150,7 +150,7 @@ if sys.platform != "win32":
                 reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
                 from .fork_exec import fork_exec
-                pid = fork_exec(cmd_python, self._fds)
+                pid = fork_exec(cmd_python, self._fds, env=process_obj.env)
                 util.debug("launched python with pid {} and cmd:\n{}"
                            .format(pid, cmd_python))
                 self.sentinel = parent_r

--- a/loky/backend/popen_loky_posix.py
+++ b/loky/backend/popen_loky_posix.py
@@ -44,12 +44,12 @@ if sys.platform != "win32":
         method = 'loky'
         DupFd = _DupFd
 
-        def __init__(self, process_obj, env={}):
+        def __init__(self, process_obj):
             sys.stdout.flush()
             sys.stderr.flush()
             self.returncode = None
             self._fds = []
-            self._launch(process_obj, env)
+            self._launch(process_obj)
 
         if sys.version_info < (3, 4):
             @classmethod
@@ -119,7 +119,7 @@ if sys.platform != "win32":
                     if self.wait(timeout=0.1) is None:
                         raise
 
-        def _launch(self, process_obj, env):
+        def _launch(self, process_obj):
 
             tracker_fd = resource_tracker._resource_tracker.getfd()
 
@@ -150,7 +150,7 @@ if sys.platform != "win32":
                 reduction._mk_inheritable(tracker_fd)
                 self._fds.extend([child_r, child_w, tracker_fd])
                 from .fork_exec import fork_exec
-                pid = fork_exec(cmd_python, self._fds, env=env)
+                pid = fork_exec(cmd_python, self._fds)
                 util.debug("launched python with pid {} and cmd:\n{}"
                            .format(pid, cmd_python))
                 self.sentinel = parent_r
@@ -197,7 +197,7 @@ if __name__ == '__main__':
                 del process.current_process()._inheriting
 
         exitcode = process_obj._bootstrap()
-    except Exception as e:
+    except Exception:
         print('\n\n' + '-' * 80)
         print('{} failed with traceback: '.format(args.process_name))
         print('-' * 80)

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -67,6 +67,7 @@ class Popen(_Popen):
 
         # copy the environment variables to set in the child process
         child_env = os.environ.copy()
+        child_env.update(process_obj.env)
 
         # bpo-35797: When running in a venv, we bypass the redirect
         # executor and launch our base Python.

--- a/loky/backend/popen_loky_win32.py
+++ b/loky/backend/popen_loky_win32.py
@@ -43,6 +43,7 @@ WINENV = (hasattr(sys, "_base_executable")
 # whose constructor takes a process object as its argument.
 #
 
+
 class Popen(_Popen):
     '''
     Start a subprocess to run the code of a process object
@@ -64,14 +65,14 @@ class Popen(_Popen):
 
         python_exe = spawn.get_executable()
 
+        # copy the environment variables to set in the child process
+        child_env = os.environ.copy()
+
         # bpo-35797: When running in a venv, we bypass the redirect
         # executor and launch our base Python.
         if WINENV and _path_eq(python_exe, sys.executable):
             python_exe = sys._base_executable
-            env = os.environ.copy()
-            env["__PYVENV_LAUNCHER__"] = sys.executable
-        else:
-            env = None
+            child_env["__PYVENV_LAUNCHER__"] = sys.executable
 
         try:
             with open(wfd, 'wb') as to_child:
@@ -88,9 +89,9 @@ class Popen(_Popen):
                     hp, ht, pid, tid = _winapi.CreateProcess(
                         python_exe, cmd,
                         None, None, inherit, 0,
-                        env, None, None)
+                        child_env, None, None)
                     _winapi.CloseHandle(ht)
-                except BaseException as e:
+                except BaseException:
                     _winapi.CloseHandle(rhandle)
                     raise
 

--- a/loky/backend/process.py
+++ b/loky/backend/process.py
@@ -16,7 +16,7 @@ class LokyProcess(BaseProcess):
 
     def __init__(self, group=None, target=None, name=None, args=(),
                  kwargs={}, daemon=None, init_main_module=False,
-                 env={}):
+                 env=None):
         if sys.version_info < (3, 3):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
@@ -26,7 +26,7 @@ class LokyProcess(BaseProcess):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
                 kwargs=kwargs, daemon=daemon)
-        self.env = env
+        self.env = {} if env is None else env
         self.authkey = self.authkey
         self.init_main_module = init_main_module
 

--- a/loky/backend/process.py
+++ b/loky/backend/process.py
@@ -26,8 +26,8 @@ class LokyProcess(BaseProcess):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
                 kwargs=kwargs, daemon=daemon)
-        self.authkey = self.authkey
         self.env = env
+        self.authkey = self.authkey
         self.init_main_module = init_main_module
 
     @staticmethod

--- a/loky/backend/process.py
+++ b/loky/backend/process.py
@@ -15,7 +15,8 @@ class LokyProcess(BaseProcess):
     _start_method = 'loky'
 
     def __init__(self, group=None, target=None, name=None, args=(),
-                 kwargs={}, daemon=None, init_main_module=False):
+                 kwargs={}, daemon=None, init_main_module=False,
+                 env={}):
         if sys.version_info < (3, 3):
             super(LokyProcess, self).__init__(
                 group=group, target=target, name=name, args=args,
@@ -26,6 +27,7 @@ class LokyProcess(BaseProcess):
                 group=group, target=target, name=name, args=args,
                 kwargs=kwargs, daemon=daemon)
         self.authkey = self.authkey
+        self.env = env
         self.init_main_module = init_main_module
 
     @staticmethod

--- a/loky/backend/spawn.py
+++ b/loky/backend/spawn.py
@@ -12,8 +12,6 @@ import runpy
 import types
 from multiprocessing import process, util
 
-from loky.backend import context
-
 
 if sys.platform != 'win32':
     WINEXE = False
@@ -60,14 +58,13 @@ def get_preparation_data(name, init_main_module=True):
     d = dict(
         log_to_stderr=util._log_to_stderr,
         authkey=bytes(process.current_process().authkey),
+        name=name,
+        sys_argv=sys.argv,
+        orig_dir=process.ORIGINAL_DIR,
+        dir=os.getcwd()
     )
 
-    if util._logger is not None:
-        d['log_level'] = util._logger.getEffectiveLevel()
-        if len(util._logger.handlers) > 0:
-            h = util._logger.handlers[0]
-            d['log_fmt'] = h.formatter._fmt
-
+    # Send sys_path and make sure the current directory will not be changed
     sys_path = [p for p in sys.path]
     try:
         i = sys_path.index('')
@@ -75,14 +72,14 @@ def get_preparation_data(name, init_main_module=True):
         pass
     else:
         sys_path[i] = process.ORIGINAL_DIR
+    d['sys_path'] = sys_path
 
-    d.update(
-        name=name,
-        sys_path=sys_path,
-        sys_argv=sys.argv,
-        orig_dir=process.ORIGINAL_DIR,
-        dir=os.getcwd()
-    )
+    # Make sure to pass the information if the multiprocessing logger is active
+    if util._logger is not None:
+        d['log_level'] = util._logger.getEffectiveLevel()
+        if len(util._logger.handlers) > 0:
+            h = util._logger.handlers[0]
+            d['log_fmt'] = h.formatter._fmt
 
     # Tell the child how to communicate with the resource_tracker
     from .resource_tracker import _resource_tracker
@@ -166,7 +163,6 @@ def prepare(data):
             _resource_tracker._fd = msvcrt.open_osfhandle(handle, 0)
         else:
             _resource_tracker._fd = data["tracker_args"]["fd"]
-
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -400,7 +400,7 @@ def _process_worker(call_queue, result_queue, initializer, initargs,
             else:
                 mp.util.info("Could not acquire processes_management_lock")
                 continue
-        except BaseException as e:
+        except BaseException:
             previous_tb = traceback.format_exc()
             try:
                 result_queue.put(_RemoteTraceback(previous_tb))
@@ -853,7 +853,7 @@ class ProcessPoolExecutor(_base.Executor):
 
     def __init__(self, max_workers=None, job_reducers=None,
                  result_reducers=None, timeout=None, context=None,
-                 initializer=None, initargs=(), env={}):
+                 initializer=None, initargs=(), env=None):
         """Initializes a new ProcessPoolExecutor instance.
 
         Args:
@@ -875,8 +875,9 @@ class ProcessPoolExecutor(_base.Executor):
             initializer: An callable used to initialize worker processes.
             initargs: A tuple of arguments to pass to the initializer.
             env: A dict of environment variable to overwrite in the child
-                process. This only works with the loky context. The environment
-                variables are set before any module load.
+                process. The environment variables are set before any module is
+                loaded. Note that this only works with the loky context and it
+                is unreliable under windows and Python2.7.
         """
         _check_system_limits()
 

--- a/loky/process_executor.py
+++ b/loky/process_executor.py
@@ -890,6 +890,7 @@ class ProcessPoolExecutor(_base.Executor):
         if context is None:
             context = get_context()
         self._context = context
+        self._env = env
 
         if initializer is not None and not callable(initializer):
             raise TypeError("initializer must be a callable")
@@ -1003,7 +1004,7 @@ class ProcessPoolExecutor(_base.Executor):
                 # Try to spawn the process with some environment variable to
                 # overwrite but it only works with the loky context for now.
                 p = self._context.Process(target=_process_worker, args=args,
-                                          env=self.env)
+                                          env=self._env)
             except TypeError:
                 p = self._context.Process(target=_process_worker, args=args)
             p._worker_exit_lock = worker_exit_lock

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -40,7 +40,7 @@ def _get_next_executor_id():
 def get_reusable_executor(max_workers=None, context=None, timeout=10,
                           kill_workers=False, reuse="auto",
                           job_reducers=None, result_reducers=None,
-                          initializer=None, initargs=()):
+                          initializer=None, initargs=(), env={}):
     """Return the current ReusableExectutor instance.
 
     Start a new instance if it has not been started already or if the previous
@@ -73,6 +73,13 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
 
     When provided, the ``initializer`` is run first in newly spawned
     processes with argument ``initargs``.
+
+    The environment variable in the child process are a copy of the values in
+    the main process. One can provide a dict ``{ENV: VAL}`` where ``ENV`` and
+    ``VAR`` are string literals to overwrite the environment variable ``ENV``
+    in the child processes to value ``VAL``. The environment variables are set
+    in the children before any module is loaded. This only works with with the
+    ``loky`` context.
     """
     with _executor_lock:
         global _executor, _executor_kwargs
@@ -97,7 +104,8 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
         kwargs = dict(context=context, timeout=timeout,
                       job_reducers=job_reducers,
                       result_reducers=result_reducers,
-                      initializer=initializer, initargs=initargs)
+                      initializer=initializer, initargs=initargs,
+                      env=env)
         if executor is None:
             mp.util.debug("Create a executor with max_workers={}."
                           .format(max_workers))
@@ -137,11 +145,12 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
 class _ReusablePoolExecutor(ProcessPoolExecutor):
     def __init__(self, submit_resize_lock, max_workers=None, context=None,
                  timeout=None, executor_id=0, job_reducers=None,
-                 result_reducers=None, initializer=None, initargs=()):
+                 result_reducers=None, initializer=None, initargs=(),
+                 env={}):
         super(_ReusablePoolExecutor, self).__init__(
             max_workers=max_workers, context=context, timeout=timeout,
             job_reducers=job_reducers, result_reducers=result_reducers,
-            initializer=initializer, initargs=initargs)
+            initializer=initializer, initargs=initargs, env=env)
         self.executor_id = executor_id
         self._submit_resize_lock = submit_resize_lock
 

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -79,7 +79,7 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     ``VAR`` are string literals to overwrite the environment variable ``ENV``
     in the child processes to value ``VAL``. The environment variables are set
     in the children before any module is loaded. This only works with with the
-    ``loky`` context and it is unstable on windows with Python2.7.
+    ``loky`` context and it is unreliable on Windows with Python 2.7.
     """
     with _executor_lock:
         global _executor, _executor_kwargs

--- a/loky/reusable_executor.py
+++ b/loky/reusable_executor.py
@@ -40,7 +40,7 @@ def _get_next_executor_id():
 def get_reusable_executor(max_workers=None, context=None, timeout=10,
                           kill_workers=False, reuse="auto",
                           job_reducers=None, result_reducers=None,
-                          initializer=None, initargs=(), env={}):
+                          initializer=None, initargs=(), env=None):
     """Return the current ReusableExectutor instance.
 
     Start a new instance if it has not been started already or if the previous
@@ -79,7 +79,7 @@ def get_reusable_executor(max_workers=None, context=None, timeout=10,
     ``VAR`` are string literals to overwrite the environment variable ``ENV``
     in the child processes to value ``VAL``. The environment variables are set
     in the children before any module is loaded. This only works with with the
-    ``loky`` context.
+    ``loky`` context and it is unstable on windows with Python2.7.
     """
     with _executor_lock:
         global _executor, _executor_kwargs
@@ -146,7 +146,7 @@ class _ReusablePoolExecutor(ProcessPoolExecutor):
     def __init__(self, submit_resize_lock, max_workers=None, context=None,
                  timeout=None, executor_id=0, job_reducers=None,
                  result_reducers=None, initializer=None, initargs=(),
-                 env={}):
+                 env=None):
         super(_ReusablePoolExecutor, self).__init__(
             max_workers=max_workers, context=context, timeout=timeout,
             job_reducers=job_reducers, result_reducers=result_reducers,

--- a/tests/_test_process_executor.py
+++ b/tests/_test_process_executor.py
@@ -909,9 +909,6 @@ class ExecutorTest:
         executor = self.executor_type(1, env={var_name: var_value})
 
         var_child = executor.submit(self._test_child_env, var_name).result()
-
-        msg = "Expected env variable {}={}, got {}".format(var_name, var_value,
-                                                           var_child)
-        assert var_child == var_value, msg
+        assert var_child == var_value
 
         executor.shutdown(wait=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,10 @@ def pytest_configure(config):
 
     warnings.simplefilter('always')
 
+    config.addinivalue_line("markers", "timeout")
+    config.addinivalue_line("markers", "broken_pool")
+    config.addinivalue_line("markers", "high_memory")
+
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--skip-high-memory"):

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -285,6 +285,9 @@ class TestLokyBackend:
 
         queue.put(os.environ.get(key, 'not set'))
 
+    @pytest.mark.xfail(sys.version_info[0] == 2 and
+                       sys.platform == "win32",
+                       reason="Can randomly fail on python2.7 and windows.")
     def test_child_env_process(self):
         import os
 

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -312,8 +312,8 @@ class TestLokyBackend:
         child_var = out_queue.get()
         p.join()
 
-        assert child_var == new_value, ("Expected var={} but got {}"
-                                        .format(new_value, child_var))
+        assert child_var == new_value, ("Expected var={} but got {}\nEnv={}"
+                                        .format(new_value, child_var, p.env))
 
     @classmethod
     def _test_terminate(cls, event):

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -292,6 +292,8 @@ class TestLokyBackend:
         value = 'loky works'
         out_queue = self.SimpleQueue()
 
+        # Test that the environment variable is correctly copied in the child
+        # process.
         os.environ[key] = value
         p = self.Process(target=self._test_child_env_vars,
                          args=(key, out_queue))
@@ -301,6 +303,18 @@ class TestLokyBackend:
 
         assert child_var == value, ("Expected var={} but got {}"
                                     .format(value, child_var))
+
+        # Test that the environment variable is correctly overwritted by using
+        # the `env` variable in Process.
+        new_value = 'loky rocks'
+        p = self.Process(target=self._test_child_env_vars,
+                         args=(key, out_queue), env={key: new_value})
+        p.start()
+        child_var = out_queue.get()
+        p.join()
+
+        assert child_var == new_value, ("Expected var={} but got {}"
+                                        .format(new_value, child_var))
 
     @classmethod
     def _test_terminate(cls, event):

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -315,7 +315,7 @@ class TestLokyBackend:
             child_var = out_queue.get()
             p.join()
 
-            assert child_var == new_value
+            assert child_var == new_value, p.env
         finally:
             del os.environ[key]
 

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -279,6 +279,29 @@ class TestLokyBackend:
         parent_connection.close()
         child_connection.close()
 
+    @staticmethod
+    def _test_child_env_vars(key, queue):
+        import os
+
+        queue.put(os.environ.get(key, 'not set'))
+
+    def test_child_env_vars(self):
+        import os
+
+        key = 'loky_child_env_test'
+        value = 'loky works'
+        out_queue = self.SimpleQueue()
+
+        os.environ[key] = value
+        p = self.Process(target=self._test_child_env_vars,
+                         args=(key, out_queue))
+        p.start()
+        child_var = out_queue.get()
+        p.join()
+
+        assert child_var == value, ("Expected var={} but got {}"
+                                    .format(value, child_var))
+
     @classmethod
     def _test_terminate(cls, event):
         # Notify the main process that child process started

--- a/tests/test_loky_backend.py
+++ b/tests/test_loky_backend.py
@@ -280,23 +280,22 @@ class TestLokyBackend:
         child_connection.close()
 
     @staticmethod
-    def _test_child_env_vars(key, queue):
+    def _test_child_env(key, queue):
         import os
 
         queue.put(os.environ.get(key, 'not set'))
 
-    def test_child_env_vars(self):
+    def test_child_env_process(self):
         import os
 
-        key = 'loky_child_env_test'
+        key = 'loky_child_env_process'
         value = 'loky works'
         out_queue = self.SimpleQueue()
 
         # Test that the environment variable is correctly copied in the child
         # process.
         os.environ[key] = value
-        p = self.Process(target=self._test_child_env_vars,
-                         args=(key, out_queue))
+        p = self.Process(target=self._test_child_env, args=(key, out_queue))
         p.start()
         child_var = out_queue.get()
         p.join()
@@ -307,8 +306,8 @@ class TestLokyBackend:
         # Test that the environment variable is correctly overwritted by using
         # the `env` variable in Process.
         new_value = 'loky rocks'
-        p = self.Process(target=self._test_child_env_vars,
-                         args=(key, out_queue), env={key: new_value})
+        p = self.Process(target=self._test_child_env, args=(key, out_queue),
+                         env={key: new_value})
         p.start()
         child_var = out_queue.get()
         p.join()


### PR DESCRIPTION
Pass environment variable to child process first to avoid mixed effect after module loads.

TODO:

- [x] write tests
- [x] implement support for windows with the loky start method
- [x] make it possible to override the env of the children without touching the `os.environ` of the parent
- [x] do a manual check when calling a bunch of `np.linalg.svd` in a loky `executor.map` loop and check that there is no over-subscription on a machine with more than 32 cores.
- [ ] (optional) implement support for windows with the spawn start method.